### PR TITLE
11 at operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 obj/*
 .cache/*
+build/*
 spec.txt
 hdql.tab.c
 hdql.tab.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ set (hdql_SOURCES src/types.cc
 	              src/ifaces/arith-op-as-scalar.c
 	              src/ifaces/arith-op-as-collection.c
 	              src/ifaces/filtered-v-compound.c
+                  src/ifaces/bound-value.c
+                  src/ifaces/bound-compound-collection.c
                   src/funcs/generic-logic.c
                   src/helpers/query.cc
                   src/helpers/query-results-handler.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,10 @@ if (BUILD_TESTS)
                           test/ht.test.cc
                           test/events-struct.cc
                           test/samples.cc
-                          test/iteration-tests.cc
+                          test/iteration-tests/singular-query.cc
+                          test/iteration-tests/arithmetics.cc
+                          test/iteration-tests/v-compound-fwd.cc
+                          test/iteration-tests/v-compound-bind.cc
                           test/cpp-api.cc
                           test/dsv.test.cc
                           test/query-product.test.cc

--- a/doc/concepts.rst
+++ b/doc/concepts.rst
@@ -2,97 +2,141 @@ Concepts cheatsheet
 ===================
 
 HDQL is a domain-specific language designed for querying deeply structured,
-hierarchical data through a unified C/C++ interface. It centers around the
+hierarchical data through a C/C++ interface. It is built around the
 concept of attribute definitions (ADs) that encode both the structural and
-access properties of data elements, forming explicit compound schemas. Queries
-in HDQL are composable and stateful, supporting operations like selection,
-filtering, and the definition of transient (virtual) attributes at runtime.
+access properties of data elements, forming explicit schemata. Queries
+in HDQL are composable and stateful objects, supporting selection,
+and filtering. The definition of transient attributes at runtime is
+anticipated for special kind of transient compound structures.
 Each query yields not only values but also associated hierarchical keys,
 enabling fine-grained identification within complex data. The C API provides
-an efficient, zero-copy interface via opaque handles and offers mechanisms
-for safe key handling. Designed with flexibility and streaming in mind,
-HDQL facilitates dynamic data introspection, event processing, and analysis
+a fairly efficient, zero-copy interface via opaque handles and offers mechanisms
+for key handling. Oriented towards streaming access model in mind,
+HDQL facilitates data introspection, event processing, and analysis
 across diverse structured datasets.
 
 Type system
 -----------
 
- * HDQL considers relation ("compound data to attribute datum")
+ * HDQL is stronly typed, meaning that types are always known and explicit
+   after expression is interpreted;
+ * HDQL considers relation ("compound data to attribute datum");
  * This relation is defined by structure called attribute definition (AD)
- * Main features of AD defined by appropriate interfaces are:
-    - arity property: collection/scalar
-    - type property: compound/atomic
- * Compounds are fully defined as set of ADs -- not less, not more.
- * Atomics are defined by ``ValueInterface``
- * Collection access is controlled by collection interface
- * Scalar access is controlled by collection interface
+ * Orthogonal features of AD defined by appropriate interfaces are:
+    - type composition property: compound or atomic;
+    - arity property: collection or scalar.
+ * Compounds are fully (only) defined as a set of ADs and name;
+ * Atomics are defined by named ``ValueInterface`` permitting for four types:
+    - logic (bool);
+    - integer;
+    - floating point;
+    - string.
+ * Collection access is controlled by collection interface defining iteration
+   and (optionally) selection routines (from C API -- via iterator);
+ * Scalar access is controlled by collection interface.
 
 This way, everything starts with defining compound as a collection
-of named ADs, each AD is defined by two interface implementations.
-Compounds (defined as a set of named ADs) form the schema for a data domain.
-Each AD encodes both the structure (arity/type) and access semantics of a datum.
+of named ADs, each AD is defined by one of two interface implementations,
+defining how attribute has to be iterated. Compounds form the schema for a
+data domain.
 
 
 Query object
 ------------
 
- * A simple query is defined by referencing AD with respect to a compound,
-   for instance ``.foo`` refers to AD named "foo" in root object.
- * Queries always relies on some implicit root compound
- * A query is a stateful generator that supports two core operations:
-   "reset" (which reinitializes the internal state and is idempotent), and
-   "yield" (which returns the current value and advances the query’s
-   internal iterator).
- * Queries can be chained resulting in the rightmost property iterated
-   by depth-first scheme. Lexically, it is expressed as concatenation
-   of properties with period (``.``) delimiter: ``.foo.bar``,
-   ``.hits.rawData.samples``
- * The chaining performs a reset/get for the leftmost query, then uses the
-   result as the root for the next simple query, and so on.
- * Query may have "selection" assigned. Lexically it corresponds to ``.foo[23]``
-   or ``.foo[2:3]``, etc. Content of selection expression is NOT part of HDQL,
-   HDQL just forwards expression in square brackets to third-party parser
-   via collection interface
- * Query may have filtering expression evaluating logic expressions to
-   restrict next state in "yield". Lexically it is written as
-   a sub-query in curly brackets after column, e.g. ``.foo{:.a > 0}``
- * Query may create transient attributes. Lexically it is written as
-   an expression with ``:=`` operator inside curly brackets: ``.foo{ c := .a+.b }``
- * It is possible to define filtering expression on newly defined transient
-   ADs: ``.foo{ newAttr := a + b : .newAttr > 100 }``
- * Multiple transient properties can be defined using
-   comma: ``.foo{a01 := .a0/.a1, a12 := .a1/.a2}``
- * Technically, transient properties are created in a *virtual compound* which
-   is defined at the stage when query is interpreted, contrary to usual
-   compounds which are defined before and are immutable
- * Transient properties are defined as full-fledged queries supporting chaining,
-   indexing and selection features.
- * Virtual compound AD refers to a synthetic interfaces with state
-   corresponding to sub-queries
- * Selection, defining transient properties and value filtering can be
-   combined in one query expression: ``.foo[1-10]{check:=.chi2/.ndf:.check<30}``
-
 Queries are the core construct of the language. They support chaining,
 collection element selection, and value-based filtering.
 
+ * A simple 1st-level query is defined by referencing AD with respect to a
+   compound, delimited with period. For instance ``.foo`` refers to AD named
+   "foo" in root object;
+ * First-level queries always relies on some implicit root compound. Other
+   level queries are chained from it as ``.foo.bar``, etc.
+ * A query is a stateful generator that supports two core operations:
+   "reset" (which reinitializes the internal state and is idempotent), and
+   "yield" (which returns the current value and advances the query’s
+   internal iterator);
+ * Queries can be chained resulting in the right-to-left properties iterated
+   by depth-first scheme. Lexically, it is expressed as concatenation (chaining)
+   of properties with period (``.``) delimiter: ``.foo.bar``,
+   ``.hits.rawData.samples``;
+ * The chaining performs a reset/get for the leftmost query, then uses the
+   result as the root for the next simple query, and so on;
+ * Query may have "selection" assigned. Lexically it corresponds to ``.foo[23]``
+   or ``.foo[2:3]``, etc. Content of selection expression is delegated to
+   external interpreters -- expressions inside ``[...]`` are delibirately made
+   to NOT be part of HDQL. HDQL interpreter forwards those expression to
+   third-party parser via collection interface;
+ * Query may have filtering expression evaluating logic expressions to
+   restrict next state in "yield". Lexically it is written as
+   a sub-query in curly brackets after column, e.g. ``.foo{:.a > 0}``.
+
+All the rest lexics is evolving around the query concept formulated this way.
+
+Virtual compounds and transient properties
+------------------------------------------
+
+Virtual compounds provides means for aliasing and re-using the queries.
+
+ * Query may create new attributes within transient compounds. Lexically it is
+   written as an expression with ``:=`` operator inside curly
+   brackets: ``.foo{ c := .a+.b }``. This
+   query results in a new (virtual) compound with property named ``c``;
+ * It is possible to define filtering expression on newly defined transient
+   compounds: ``.foo{ newAttr := a + b : .newAttr > 100 }``;
+ * Multiple transient properties in a virtual compound can be defined using
+   comma: ``.foo{a01 := .a0/.a1, a12 := .a1/.a2}``;
+ * Technically, transient properties are created in a *virtual compound* which
+   is defined at the stage when query is interpreted, contrary to usual
+   compounds which are defined before and are immutable;
+ * Transient properties are merely aliases for queries. This way they support
+   chaining, indexing and selection features, as ordinary ADs;
+ * Virtual compound AD refers to a synthetic interfaces with state
+   corresponding to sub-queries;
+ * Selection, defining transient properties and value filtering can be
+   combined in one query expression: ``.foo[1-10]{check:=.chi2/.ndf:.check<30}``.
+
+Virtual compounds always have a parent compound they are based on. Inheritance
+chain of the copmpounds eventually ends with some non-virtual compound defined
+by user's schema.
+
+.. todo::
+
+   It is possible that we will introduce ``as`` keyword alias for ``:=``
+   operator as some user seemed to prefer keywords
+   notation: ``{.uno as one, .dos.tres as three}``.
+
+Binding queries and bound virtual compounds
+-------------------------------------------
+
+ * A virtual compound can be *bound* to a query within it, resulting in a
+   collection. The ``*`` operator prefixing the query expression: ``{h := *.hits}``;
+ * Bound virtual compound is a collection of compounds, resulting each compound
+   instance defined for each element.
+
+.. todo::
+
+   In keyword-based syntax, we will probably add ``each from`` sentence instead
+   of ``*`` operator: ``{each hit from .hits}``.
 
 Query keys
 ----------
 
  * Every "yield" operation results in not only the query result itself,
    but also key or a list of "keys", where each "key" item corresponds
-   to a simple query (a dereferenced AD, including scalars)
+   to a simple query (a dereferenced AD, including scalars);
  * Transient properties create branches in the keys list, at the memory level
    expressed as nested lists. For instance ``.one{foo := .two}.foo``
    will result in one nested list to resolve transient property ``foo`` in the
-   main list.
+   main list;
  * From C API perspective "keys" are rather complex structure including nested
    keys lists and trivial placeholders corresponding to scalar attribute
-   dereferencing (since every simple query operation results in a key)
+   dereferencing (since every simple query operation results in a key);
  * Because of its complexity, dealing with keys list directly for the purpose
    of obtaining their values is rather discouraged. Instead HDQL C API provides
-   "key view" structure (``hdql_KeyView``) which maps meaningful keys into
-   flat C array of structures with resolved value interfaces.
+   "key view" structure (``hdql_KeyView``) which maps meaningful keys from
+   their sparse computation-efficient branching structure into
+   flat C array of structures with resolved value interfaces;
  * Upon dereferencing a collection it is possible to tag a collection
    key for further handling in user API. Lexically it is expressed as
    arbitrary token given after ``->`` delimiter in square brackets. For instance
@@ -103,26 +147,25 @@ User code is recommended to prefer ``hdql_KeyView`` and utilize query-time label
 for meaningful access instead of direct usage of keys. The raw keys structure
 remains accessible at the API level, though in practice ``hdql_KeyView`` should
 be preferred. Skipping key materialization entirely may offer a minor
-performance gain in specific scenarios.
-
+performance gain in specific scenarios (anticipated by the evaluation API).
 
 C API
 -----
 
  * All the definitions (atomic types, compounds, functions, etc) are stored
    in the structure referred as "context": ``hdql_Context``. It is opaque for
-   user code and exposes limited API.
+   user code and exposes limited API;
  * Context is used to interpret query expression into C data structure called
-   ``hdql_Query``. It is opaque for user code and exposes limited API.
+   ``hdql_Query``. It is opaque for user code and exposes limited API;
  * After query is interpreted, it is possible to inspect the AD returned by
    rightmost simple query in query chain. This AD is called "top AD" and
-   can be obtained by ``hdql_query_top_attr()`` function
+   can be obtained by ``hdql_query_top_attr()`` function;
  * A query can be applied to the data structure of type corresponding to the
    root compound in order to iterate over values defined by query expression
-   (which are of type defined by top AD)
+   (which are of type defined by top AD);
  * Even if the top AD is a collection, the query engine flattens this
    via iteration -- so user code should treat the result as single values
-   per every "yield" call.
+   per every yielding ("evaluate query") call;
  * Query engine avoids copying of the values as much as possible. Everything
    related to particular data (access, dereferencing, forwarding) is done
    via user-defined interfaces and is hidden behind opaque
@@ -131,7 +174,8 @@ C API
    type ``hdql_Datum_t``.
  * Checking/guaranteeing type consistency for provided and yielded pointers
    is the user's code responsibility. HDQL engine is built to guarantee
-   type integrity according to rules defined by AD interfaces.
+   type integrity as long as user calls follows the rules defined by AD
+   interfaces;
  * A compiled query (``hdql_Query`` instance) maintains internal state and is
    *not thread-safe*. It should only be used with one root datum at a
    time. However, due to its low memory footprint, multiple instances of the

--- a/doc/note-on-binding.rst
+++ b/doc/note-on-binding.rst
@@ -1,0 +1,33 @@
+Note about binding operator
+===========================
+
+For simple case of single query like ``{h:=.hits}`` and ``{h:=*.hits}`` the
+difference may be not obvious at first glance: the first results in a scalar
+item of virtual compound type defined for each root one, the second results
+in a collection of items defined for every "hit" in ``.hits``. However, for
+more complex case like ``{t:=.tracks, h:=.hits}`` and
+``{t:=*.tracks, h:=*.hits}`` the difference is very important as the second
+one results in a Cartesian product -- new item of virtual compound type is
+returned by a query for each unique pair of hit and track from the collections.
+
+This binding operator transcends some fundamental limitations of maintaining
+single chain of iterators within a single query. For instance, if each ``hits``
+compound element defines ``amplitude`` and ``time`` scalar atomic properties
+and root object defines ``masterTime`` scalar atomic, it is not otherwise
+possible to iterate simultaneously over pairs of amplitude and time minus
+master time. Query like ``{dt := hits.time - .masterTime, a := hits.amplitude}``
+will result in ``dt`` and ``a`` being independent properties, while in
+the compound defined on top of ``.hits`` (considering each hit from collection)
+there is no means to request ``masterTime`` from parent compound.
+
+Generally, it seeemed that three operators are somewhat equivalent in the
+expressive capabilities and the impact on evaluation model they can offer:
+
+- Binding operator ``{h:=*.hits, mt:=.masterTime}{dt:=h.time - .mt, amp:=h.amplitude}``
+- Cartesian product, like ``{p:=product(.hits, .masterTime)}{p.t - p.masterTime, p.amplitude}``
+- Access to previous query in chain ``.hits{dt := .t - parent.masterTime, amp:=.amplitude}``
+
+While parent query access introduce complications to the existing query state
+model, first option was choosen over Cartesian product function because it is
+fairly explicit and is seemingly more natural with respect to existing syntax.
+

--- a/hdql.l
+++ b/hdql.l
@@ -71,7 +71,6 @@ identifier  (({L}({L}|{D})*)|(#{D}+))
 "<<="           {return T_LBSHIFTE;}
 ","             {return T_COMMA;}
 "."             {return T_PERIOD;}
-"@"             {return T_AT; }
 ([[:digit:]]{-}[0])[[:digit:]]*       {   char * endptr;
                     long val = strtol( yytext, &endptr, 0 );
                     int ec = errno;

--- a/hdql.l
+++ b/hdql.l
@@ -7,7 +7,7 @@ D           [0-9]
 L           [a-zA-Z_\\]
 UL          [A-Z_]
 DTNAME      {UL}
-identifier  {L}({L}|{D})*
+identifier  (({L}({L}|{D})*)|(#{D}+))
 
 %{
 #include <stdio.h>
@@ -71,6 +71,7 @@ identifier  {L}({L}|{D})*
 "<<="           {return T_LBSHIFTE;}
 ","             {return T_COMMA;}
 "."             {return T_PERIOD;}
+"@"             {return T_AT; }
 ([[:digit:]]{-}[0])[[:digit:]]*       {   char * endptr;
                     long val = strtol( yytext, &endptr, 0 );
                     int ec = errno;

--- a/hdql.y
+++ b/hdql.y
@@ -21,8 +21,8 @@ struct hdql_AnnotatedSelection {
 typedef struct Workspace {
     struct {
         const struct hdql_Compound * compoundPtr;
-        char * newAttributeName;  /* XXX, unused */
-        unsigned int posCompoundNArg;
+        unsigned int posCompoundNArg:31;
+        unsigned int isBound:1;  /* XXX, user for debug purposes only */
     } compoundStack[HDQL_COMPOUNDS_STACK_MAX_DEPTH];
     unsigned char compoundStackTop;
     struct hdql_Context * context;
@@ -67,10 +67,12 @@ static struct hdql_Compound *
 _vcompound_append_with_query(YYLTYPE * yyloc, struct Workspace * ws, yyscan_t yyscanner
             , struct hdql_Compound * vCompound
             , char * attrName, struct hdql_Query * q
+            , bool isBinding
             );
 static struct hdql_Compound *
 _vcompound_def_start(YYLTYPE * yyloc, struct Workspace * ws, yyscan_t yyscanner
         , char * attrName, struct hdql_Query * firstQuery
+        , bool isBinding
         );
 
 static struct hdql_Query *
@@ -534,6 +536,8 @@ const struct hdql_Compound * hdql_parser_top_compound(struct Workspace *);
                     if(0 != rc) return rc;
                 } scopedDefs T_RCRLBC {
                     int rc;
+                    assert( (bool) hdql_virtual_compound_is_bound($4.compoundPtr)
+                         == (0x1 == ws->compoundStack[ws->compoundStackTop].isBound) ); /* XXX */
                     struct hdql_Query * scopeQuery = _new_virtual_compound_query(
                             &yyloc, ws, yyscanner,
                             $4.compoundPtr, $4.filter);
@@ -548,6 +552,8 @@ const struct hdql_Compound * hdql_parser_top_compound(struct Workspace *);
                     assert($$ == $1);
                 }
             | T_LCRLBC scopedDefs T_RCRLBC {
+                    assert( (bool) hdql_virtual_compound_is_bound($2.compoundPtr)
+                         == (0x1 == ws->compoundStack[ws->compoundStackTop].isBound) ); /* XXX */
                     struct hdql_Query * scopeQuery = _new_virtual_compound_query(
                             &yyloc, ws, yyscanner,
                             $2.compoundPtr, $2.filter);
@@ -582,41 +588,61 @@ vCompoundDef : vNamedCompoundDef
              ;
 
 vNamedCompoundDef : T_IDENTIFIER T_WALRUS aQExpr {
-                struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, $1, $3);
+                struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, $1, $3, false);
                 if(!nvc) { free($1); return HDQL_BAD_QUERY_EXPRESSION; }
                 $$.compoundPtr = nvc;
             }
-            | vNamedCompoundDef T_COMMA {
-                /* TODO: forgot, why we needed mid-rule action here. This is
-                 * porably related to define nested v-compounds, yet in principle,
-                 * compound stack push/pop should do this for us. See also same
-                 * note for vPositionalCompoundDef */
-                ws->compoundStack[ws->compoundStackTop].compoundPtr = $1.compoundPtr;
-            } T_IDENTIFIER T_WALRUS aQExpr {
+            | T_IDENTIFIER T_WALRUS T_ASTERISK aQExpr {
+                struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, $1, $4, true);
+                if(!nvc) { free($1); return HDQL_BAD_QUERY_EXPRESSION; }
+                $$.compoundPtr = nvc;
+            }
+            | vNamedCompoundDef T_COMMA T_IDENTIFIER T_WALRUS aQExpr {
                 struct hdql_Compound * vc = _vcompound_append_with_query(&yyloc, ws, yyscanner
-                            , $1.compoundPtr, $4, $6);
-                if(!vc) { free($4); return HDQL_BAD_QUERY_EXPRESSION; }
+                            , $1.compoundPtr, $3, $5, false);
+                if(!vc) { free($3); return HDQL_BAD_QUERY_EXPRESSION; }
+                $$.compoundPtr = vc;
+            }
+            | vNamedCompoundDef T_COMMA T_IDENTIFIER T_WALRUS T_ASTERISK aQExpr {
+                struct hdql_Compound * vc = _vcompound_append_with_query(&yyloc, ws, yyscanner
+                            , $1.compoundPtr, $3, $6, true);
+                if(!vc) { free($3); return HDQL_BAD_QUERY_EXPRESSION; }
+                ws->compoundStack[ws->compoundStackTop].isBound = 0x1;
                 $$.compoundPtr = vc;
             }
             ;
 
 vPositionalCompoundDef : aQExpr {
                 char * attrName = strdup("#1");
-                struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, attrName, $1);
+                struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, attrName, $1, false);
                 if(!nvc) { free(attrName); return HDQL_BAD_QUERY_EXPRESSION; }
                 ws->compoundStack[ws->compoundStackTop].posCompoundNArg = 2;
                 $$.compoundPtr = nvc;
             }
-            | vPositionalCompoundDef T_COMMA {
-                /* TODO: see same example for vNamedCompoundDef */
-                ws->compoundStack[ws->compoundStackTop].compoundPtr = $1.compoundPtr;
-            } aQExpr {
+            | T_ASTERISK aQExpr {
+                char * attrName = strdup("#1");
+                struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, attrName, $2, true);
+                if(!nvc) { free(attrName); return HDQL_BAD_QUERY_EXPRESSION; }
+                ws->compoundStack[ws->compoundStackTop].posCompoundNArg = 2;
+                $$.compoundPtr = nvc;
+            }
+            | vPositionalCompoundDef T_COMMA aQExpr {
                 char bf[32];
                 snprintf(bf, sizeof(bf), "#%u", ws->compoundStack[ws->compoundStackTop].posCompoundNArg++);
                 char * attrName = strdup(bf);
                 struct hdql_Compound * vc = _vcompound_append_with_query(&yyloc, ws, yyscanner
-                            , $1.compoundPtr, attrName, $4);
+                            , $1.compoundPtr, attrName, $3, false);
                 if(!vc) { free(attrName); return HDQL_BAD_QUERY_EXPRESSION; }
+                $$.compoundPtr = vc;
+            }
+            | vPositionalCompoundDef T_COMMA T_ASTERISK aQExpr {
+                char bf[32];
+                snprintf(bf, sizeof(bf), "#%u", ws->compoundStack[ws->compoundStackTop].posCompoundNArg++);
+                char * attrName = strdup(bf);
+                struct hdql_Compound * vc = _vcompound_append_with_query(&yyloc, ws, yyscanner
+                            , $1.compoundPtr, attrName, $4, true);
+                if(!vc) { free(attrName); return HDQL_BAD_QUERY_EXPRESSION; }
+                ws->compoundStack[ws->compoundStackTop].isBound = 0x1;
                 $$.compoundPtr = vc;
             }
             ;
@@ -679,7 +705,8 @@ _push_cmpd(struct Workspace * ws, const struct hdql_Compound * cmpd) {
     }
     //++(ws->compoundStackTop); // xxx?
     ws->compoundStack[++(ws->compoundStackTop)].compoundPtr = cmpd /*topAttrDef->typeInfo.compound*/;
-    ws->compoundStack[   ws->compoundStackTop ].newAttributeName = NULL;
+    ws->compoundStack[  (ws->compoundStackTop)].posCompoundNArg = 0;
+    ws->compoundStack[  (ws->compoundStackTop)].isBound = 0;  /* XXX */
     return 0;
 }
 
@@ -698,7 +725,7 @@ hdql_parser_top_compound(struct Workspace * ws) {
     return ws->compoundStack[ws->compoundStackTop].compoundPtr;
 }
 
-/* An utility function: resolves query list till the topmost compound,
+/* An utility function: resolves forwarding queries till the topmost compound,
  * correctly accounting for recursive queries */
 static int
 _resolve_query_top_as_compound( struct hdql_Query * q
@@ -734,8 +761,9 @@ _resolve_query_top_as_compound( struct hdql_Query * q
     return 0;  // ok
 }  // _resolve_query_top_as_compound()
 
-static hdql_Datum_t _trivial_dereference( hdql_Datum_t d
-    , hdql_Datum_t dd
+/* returns "owner" as result */
+static hdql_Datum_t _dereference_to_self( hdql_Datum_t d
+    , hdql_Datum_t dynData
     , struct hdql_CollectionKey * key
     , const hdql_Datum_t defData
     , hdql_Context_t ctx
@@ -744,8 +772,9 @@ static hdql_Datum_t _trivial_dereference( hdql_Datum_t d
 static void _transient_dtr__virtual_compound(hdql_Datum_t q_, hdql_Context_t ctx) {
     hdql_query_destroy((struct hdql_Query *) q_, ctx);
 }
-/* This function gets called upon finalizing scope operator (after `}'
- * in `{...}' and produces filtering or trivial query node that should return
+/* This function gets called upon finalizing a new virtual compound with scope
+ * operator (after `}' in `{...}' and produces filtering or trivial query node
+ * that should return
  * a virtual compound instance. Virtual compound itself is built and defined
  * up to the moment this function gets invoked, we just have to pack it into
  * a query node. Not-so-trivial case arises if filtering expression was given
@@ -769,11 +798,11 @@ _new_virtual_compound_query( YYLTYPE * yylloc
                            , struct hdql_Query * filterQuery
                            ) {
     struct hdql_AttrDef * vCompoundAttrDef;
-    #if 1
+    if(!hdql_virtual_compound_is_bound(vCompoundPtr)) {
         struct hdql_ScalarAttrInterface iface;
         if(NULL == filterQuery) {
             bzero(&iface, sizeof(iface));
-            iface.dereference = _trivial_dereference;
+            iface.dereference = _dereference_to_self;
         } else {
             iface = _hdql_gFilteredCompoundIFace;
             iface.definitionData = (hdql_Datum_t) filterQuery;
@@ -785,28 +814,40 @@ _new_virtual_compound_query( YYLTYPE * yylloc
                 , NULL  /* ........... key copy callback */
                 , ws->context  /* .... context */
                 );
-    #else
-        struct hdql_CollectionAttrInterface iface;
         if(NULL == filterQuery) {
-            bzero(&iface, sizeof(iface));
-            iface.dereference = _trivial_dereference;
+            hdql_attr_def_set_transient(vCompoundAttrDef, NULL);
         } else {
-            iface = ;  // TODO
-            iface.definitionData = (hdql_Datum_t) filterQuery;
+            hdql_attr_def_set_transient(vCompoundAttrDef, _transient_dtr__virtual_compound);
         }
+    } else {
+        /* Binding compounds always results in a collection: {*.a} where .a is
+         * collection will create a collection of items of v-compound type, one
+         * item per each element from .a.
+         *
+         * Re-setting or advancing query to bound v-compound shall cause
+         * evaluation of the bound forwarding queries first, setting
+         * corresponding attributes. */
+        struct hdql_CollectionAttrInterface iface = _hdql_gBindingCompoundCollectionIFace;
+        /* filtering query and pointer to (not yet finalized) virtual compound
+         * definition have to be transferred to the iterator instantiation
+         * in order to compose (optionally filtered) sequence of Cartesian
+         * product results */
+        struct hdql_BindingCompoundCollectionDefData * dd
+                = hdql_alloc(ws->context, struct hdql_BindingCompoundCollectionDefData);
+        dd->vCompound = vCompoundPtr;
+        dd->filterQuery = filterQuery;
+        iface.definitionData = (hdql_Datum_t) dd;
+        /* create attribute definition */
         vCompoundAttrDef = hdql_attr_def_create_compound_collection(
                   vCompoundPtr  /* ... compound ptr */
-                , &iface  /* ......... scalar iface ptr */
-                , 0x0  /* ............ key type code */
-                , NULL  /* ........... key copy callback */
+                , &iface  /* ......... collection iface ptr */
+                , 0x0  /* ............ key type code (TODO?) */
+                , NULL  /* ........... key copy callback (TODO?) */
                 , ws->context  /* .... context */
                 );
-        // ...
-    #endif
-    if(NULL == filterQuery) {
-        hdql_attr_def_set_transient(vCompoundAttrDef, NULL);
-    } else {
-        hdql_attr_def_set_transient(vCompoundAttrDef, _transient_dtr__virtual_compound);
+        // ... TODO?
+        // TODO: mark bound query as transient
+        printf("XXX created bound virtual compound\n");  // XXX
     }
     struct hdql_Query * q = hdql_query_create(vCompoundAttrDef, NULL, ws->context);
     hdql_query_set_transient_subject_ownership(q);
@@ -1031,35 +1072,101 @@ static struct hdql_Compound *
 _vcompound_append_with_query(YYLTYPE * yyloc, struct Workspace * ws, yyscan_t yyscanner
             , struct hdql_Compound * vCompound
             , char * attrName, struct hdql_Query * q
+            , bool isBinding
             ) {
     assert(hdql_compound_is_virtual(vCompound));
+    int rc;
     /* define new attribute of a virtual compound,
      * named as T_IDENTIFIER with query as a result.
      * New (virtual) attribute definition inherits what is
      * provided by query's top attribute */
-    struct hdql_AttrDef * newAttrDef
-        = hdql_attr_def_create_fwd_query(q, ws->context);
+    struct hdql_AttrDef * newAttrDef;
+    if(!isBinding) {
+        /* This is a "forwarding query" -- an attribute of virtual compound
+         * referencing some subquery (but not the result) */
+        newAttrDef = hdql_attr_def_create_fwd_query(q, ws->context, &rc);
+    } else {
+        /* This is bound attribute (value that is managed externally). This
+         * case is mainly meant to be applied to collections, resulting in an
+         * element type. For instance, consider `*.hits`, `*.tracks.hits`, etc.
+         *
+         * Note, that important case of applying filtering expression will
+         * result in a scalar top attribute: `*.hits{:.x>4}`, so we generally
+         * permit for last sub-query to be of scalar type (`*.hits.x` is ok),
+         * but we refuse binding fully scalar attributes (queries chain not
+         * containing collections at all, e.g. `*.eventID`).
+         *
+         * The attribute basically inherits what query results in, except for
+         * the interface, which will forward call to the Cartesian product
+         * result */
+        const struct hdql_AttrDef * queryTopAD = hdql_query_top_attr(q);
+        if(hdql_query_is_fully_scalar(q)) {
+            /* we print string of top attr, but this can be misleading, as it
+             * can be a scalar, actually (we're refusing to create only fully
+             * scalar queries; perhaps, we should reconsider this message? */
+            char buf[128];
+            hdql_top_attr_str(queryTopAD, buf, sizeof(buf), ws->context);
+            hdql_error(yyloc, ws, yyscanner
+                , "useless definition of binding attribute \"%s\" resulting in"
+                  " `%s' for virtual"
+                  " compound type based on `%s' since full corresponding"
+                  " sub-query does not contain any collection"
+                , attrName, buf
+                , hdql_compound_get_name(hdql_virtual_compound_get_parent(vCompound))
+                );
+            return NULL;
+        }
+        newAttrDef = hdql_attr_def_create_bound(q, ws->context, &rc);
+        printf("XXX added bound attribute\n");  // XXX
+    }
+    if(!newAttrDef) {
+        hdql_error(yyloc, ws, yyscanner
+            , "failed to define %sattribute \"%s\" for virtual"
+              " compound type based on `%s'; error %d: %s"
+            , isBinding ? "binding " : ""
+            , attrName
+            , hdql_compound_get_name(hdql_virtual_compound_get_parent(vCompound))
+            , rc
+            , hdql_err_str(rc)
+            );
+        return NULL;
+    }
     /* Add new attribute to virtual compound */
-    int rc = hdql_compound_add_attr(vCompound, attrName, newAttrDef);
+    rc = hdql_compound_add_attr(vCompound, attrName, newAttrDef);
     if(0 == rc) return vCompound;
     hdql_error(yyloc, ws, yyscanner
         , "failed to define attribute \"%s\" for virtual"
-          " compound type based on `%s'; error code %d"
+          " compound type based on `%s'; error %d: %s"
         , attrName
         , hdql_compound_get_name(hdql_virtual_compound_get_parent(vCompound))
-        , rc );
+        , rc
+        , hdql_err_str(rc)
+        );
+    /* TODO: destroy attr def? */
     return NULL;
 }
 
 static struct hdql_Compound *
 _vcompound_def_start(YYLTYPE * yyloc, struct Workspace * ws, yyscan_t yyscanner
         , char * attrName, struct hdql_Query * firstQuery
+        , bool isBinding
         ) {
     /* _substitute_ compound with new virtual one */
     struct hdql_Compound * vCompound
                 = hdql_virtual_compound_new(hdql_parser_top_compound(ws), ws->context);
     hdql_context_add_virtual_compound(ws->context, vCompound);
-    return _vcompound_append_with_query(yyloc, ws, yyscanner, vCompound, attrName, firstQuery);
+    struct hdql_Compound * nvc = _vcompound_append_with_query(
+            yyloc, ws, yyscanner, vCompound, attrName, firstQuery, isBinding);
+    if(nvc) {
+        ws->compoundStack[ws->compoundStackTop].compoundPtr = nvc;
+        ws->compoundStack[ws->compoundStackTop].posCompoundNArg = 0;
+        ws->compoundStack[ws->compoundStackTop].isBound = isBinding ? 0x1 : 0x0;
+    } else {
+        /* TODO: check that we're not ending with segfaults or leaks
+         * here (when query appending has failed) */
+        hdql_virtual_compound_destroy(vCompound, ws->context);
+    }
+    return nvc;
 }
 
 /* 
@@ -1082,7 +1189,8 @@ hdql_compile_query( const char * strexpr
     ws.context = ctx;
     /* set data type lookup table */
     ws.compoundStack[0].compoundPtr = rootCompound;
-    ws.compoundStack[0].newAttributeName = NULL;
+    ws.compoundStack[0].posCompoundNArg = 0;
+    ws.compoundStack[0].isBound = 0x0;
     ws.compoundStackTop = 0;
     /* init result */
     ws.query = NULL;

--- a/hdql.y
+++ b/hdql.y
@@ -269,7 +269,7 @@ const struct hdql_Compound * hdql_parser_top_compound(struct Workspace *);
             }
             | argsList T_COMMA aQExpr
             {
-                $$->nextArgument = (struct hdql_FuncArgList*)
+                $$ = (struct hdql_FuncArgList*)
                         malloc(sizeof(struct hdql_FuncArgList));
                 $$->thisArgument = $3;
                 $$->nextArgument = $1;

--- a/hdql.y
+++ b/hdql.y
@@ -842,7 +842,7 @@ _new_virtual_compound_query( YYLTYPE * yylloc
                   vCompoundPtr  /* ... compound ptr */
                 , &iface  /* ......... collection iface ptr */
                 , 0x0  /* ............ key type code (TODO?) */
-                , NULL  /* ........... key copy callback (TODO?) */
+                , hdql_bound_compound_key_reserve  /* key reserve callback */
                 , ws->context  /* .... context */
                 );
         // ... TODO?

--- a/hdql.y
+++ b/hdql.y
@@ -589,59 +589,59 @@ vCompoundDef : vNamedCompoundDef
 
 vNamedCompoundDef : T_IDENTIFIER T_WALRUS aQExpr {
                 struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, $1, $3, false);
-                if(!nvc) { free($1); return HDQL_BAD_QUERY_EXPRESSION; }
+                free($1);
+                if(!nvc) { return HDQL_BAD_QUERY_EXPRESSION; }
                 $$.compoundPtr = nvc;
             }
             | T_IDENTIFIER T_WALRUS T_ASTERISK aQExpr {
                 struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, $1, $4, true);
-                if(!nvc) { free($1); return HDQL_BAD_QUERY_EXPRESSION; }
+                free($1);
+                if(!nvc) { return HDQL_BAD_QUERY_EXPRESSION; }
                 $$.compoundPtr = nvc;
             }
             | vNamedCompoundDef T_COMMA T_IDENTIFIER T_WALRUS aQExpr {
                 struct hdql_Compound * vc = _vcompound_append_with_query(&yyloc, ws, yyscanner
                             , $1.compoundPtr, $3, $5, false);
-                if(!vc) { free($3); return HDQL_BAD_QUERY_EXPRESSION; }
+                free($3);
+                if(!vc) { return HDQL_BAD_QUERY_EXPRESSION; }
                 $$.compoundPtr = vc;
             }
             | vNamedCompoundDef T_COMMA T_IDENTIFIER T_WALRUS T_ASTERISK aQExpr {
                 struct hdql_Compound * vc = _vcompound_append_with_query(&yyloc, ws, yyscanner
                             , $1.compoundPtr, $3, $6, true);
-                if(!vc) { free($3); return HDQL_BAD_QUERY_EXPRESSION; }
+                free($3); 
+                if(!vc) { return HDQL_BAD_QUERY_EXPRESSION; }
                 ws->compoundStack[ws->compoundStackTop].isBound = 0x1;
                 $$.compoundPtr = vc;
             }
             ;
 
 vPositionalCompoundDef : aQExpr {
-                char * attrName = strdup("#1");
-                struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, attrName, $1, false);
-                if(!nvc) { free(attrName); return HDQL_BAD_QUERY_EXPRESSION; }
+                struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, "#1", $1, false);
+                if(!nvc) { return HDQL_BAD_QUERY_EXPRESSION; }
                 ws->compoundStack[ws->compoundStackTop].posCompoundNArg = 2;
                 $$.compoundPtr = nvc;
             }
             | T_ASTERISK aQExpr {
-                char * attrName = strdup("#1");
-                struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, attrName, $2, true);
-                if(!nvc) { free(attrName); return HDQL_BAD_QUERY_EXPRESSION; }
+                struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, "#1", $2, true);
+                if(!nvc) { return HDQL_BAD_QUERY_EXPRESSION; }
                 ws->compoundStack[ws->compoundStackTop].posCompoundNArg = 2;
                 $$.compoundPtr = nvc;
             }
             | vPositionalCompoundDef T_COMMA aQExpr {
-                char bf[32];
-                snprintf(bf, sizeof(bf), "#%u", ws->compoundStack[ws->compoundStackTop].posCompoundNArg++);
-                char * attrName = strdup(bf);
+                char attrName[16];
+                snprintf(attrName, sizeof(attrName), "#%u", ws->compoundStack[ws->compoundStackTop].posCompoundNArg++);
                 struct hdql_Compound * vc = _vcompound_append_with_query(&yyloc, ws, yyscanner
                             , $1.compoundPtr, attrName, $3, false);
-                if(!vc) { free(attrName); return HDQL_BAD_QUERY_EXPRESSION; }
+                if(!vc) { return HDQL_BAD_QUERY_EXPRESSION; }
                 $$.compoundPtr = vc;
             }
             | vPositionalCompoundDef T_COMMA T_ASTERISK aQExpr {
-                char bf[32];
-                snprintf(bf, sizeof(bf), "#%u", ws->compoundStack[ws->compoundStackTop].posCompoundNArg++);
-                char * attrName = strdup(bf);
+                char attrName[16];
+                snprintf(attrName, sizeof(attrName), "#%u", ws->compoundStack[ws->compoundStackTop].posCompoundNArg++);
                 struct hdql_Compound * vc = _vcompound_append_with_query(&yyloc, ws, yyscanner
                             , $1.compoundPtr, attrName, $4, true);
-                if(!vc) { free(attrName); return HDQL_BAD_QUERY_EXPRESSION; }
+                if(!vc) { return HDQL_BAD_QUERY_EXPRESSION; }
                 ws->compoundStack[ws->compoundStackTop].isBound = 0x1;
                 $$.compoundPtr = vc;
             }
@@ -772,6 +772,16 @@ static hdql_Datum_t _dereference_to_self( hdql_Datum_t d
 static void _transient_dtr__virtual_compound(hdql_Datum_t q_, hdql_Context_t ctx) {
     hdql_query_destroy((struct hdql_Query *) q_, ctx);
 }
+
+static void _transient_dtr__bound_virtual_compound(hdql_Datum_t dd_, hdql_Context_t ctx) {
+    assert(dd_);
+    struct hdql_BindingCompoundCollectionDefData * dd
+                = hdql_cast(ws->context, struct hdql_BindingCompoundCollectionDefData, dd_);
+    //dd->vCompound = vCompoundPtr;
+    if(dd->filterQuery)
+        hdql_query_destroy(dd->filterQuery, ctx);
+    hdql_context_free(ctx, (hdql_Datum_t) dd);
+}
 /* This function gets called upon finalizing a new virtual compound with scope
  * operator (after `}' in `{...}' and produces filtering or trivial query node
  * that should return
@@ -784,12 +794,7 @@ static void _transient_dtr__virtual_compound(hdql_Datum_t q_, hdql_Context_t ctx
  *  
  * up to the closing `}' virtual compound has been composed already, we shall
  * provide the parser with query node attributed to this v-compound in order
- * it will be capable to resolve `.e'.
- *
- * XXX Note, this query is always a scalar
- * XXX instance (there is no way in HDQL currently to "split" single instance into
- * XXX a collection of items within the "scope operator"). This scalar is optional
- * XXX as filtering expression can result of the instance to be declined. */
+ * it will be capable to resolve `.e'. */
 static struct hdql_Query *
 _new_virtual_compound_query( YYLTYPE * yylloc
                            , Workspace_t ws
@@ -845,9 +850,7 @@ _new_virtual_compound_query( YYLTYPE * yylloc
                 , hdql_bound_compound_key_reserve  /* key reserve callback */
                 , ws->context  /* .... context */
                 );
-        // ... TODO?
-        // TODO: mark bound query as transient
-        printf("XXX created bound virtual compound\n");  // XXX
+        hdql_attr_def_set_transient(vCompoundAttrDef, _transient_dtr__bound_virtual_compound);
     }
     struct hdql_Query * q = hdql_query_create(vCompoundAttrDef, NULL, ws->context);
     hdql_query_set_transient_subject_ownership(q);
@@ -1117,7 +1120,6 @@ _vcompound_append_with_query(YYLTYPE * yyloc, struct Workspace * ws, yyscan_t yy
             return NULL;
         }
         newAttrDef = hdql_attr_def_create_bound(q, ws->context, &rc);
-        printf("XXX added bound attribute\n");  // XXX
     }
     if(!newAttrDef) {
         hdql_error(yyloc, ws, yyscanner

--- a/hdql.y
+++ b/hdql.y
@@ -24,6 +24,7 @@ typedef struct Workspace {
         char * newAttributeName;
     } compoundStack[HDQL_COMPOUNDS_STACK_MAX_DEPTH];
     unsigned char compoundStackTop;
+    unsigned int posCompoundNArg;
     struct hdql_Context * context;
     struct hdql_Query * query;
     /* shortcuts */
@@ -62,6 +63,16 @@ _new_virtual_compound_query( YYLTYPE * yylloc
                            , struct hdql_Compound * compoundPtr
                            , struct hdql_Query * filterPtr
                            );
+static struct hdql_Compound *
+_vcompound_append_with_query(YYLTYPE * yyloc, struct Workspace * ws, yyscan_t yyscanner
+            , struct hdql_Compound * vCompound
+            , char * attrName, struct hdql_Query * q
+            );
+static struct hdql_Compound *
+_vcompound_def_start(YYLTYPE * yyloc, struct Workspace * ws, yyscan_t yyscanner
+        , char * attrName, struct hdql_Query * firstQuery
+        );
+
 static struct hdql_Query *
 _new_function( YYLTYPE * yyloc, struct Workspace * ws, yyscan_t yyscanner
              , const char * funcName
@@ -150,7 +161,7 @@ const struct hdql_Compound * hdql_parser_top_compound(struct Workspace *);
 %token T_DBL_CAP "^^" T_DBL_AMP "&&" T_DBL_PIPE "||"
 %token T_LBC "(" T_RBC ")" T_LCRLBC "{" T_RCRLBC "}"
 %token T_EXCLMM "!" T_QUESTIONMM "?" T_COLON ":"
-%token T_GT ">" T_GTE ">=" T_LT "<" T_LTE "<=" T_EQ "==" T_NE "!=" T_WALRUS ":="
+%token T_GT ">" T_GTE ">=" T_LT "<" T_LTE "<=" T_EQ "==" T_NE "!=" T_WALRUS ":=" T_AT "@"
 %token T_AMP "&" T_PIPE "|" T_CAP "^"
 %token T_INCREMENT "++" T_DECREMENT "--"
 %token T_PLUSE "+=" T_MINUSE "-=" T_RBSHIFTE ">>=" T_LBSHIFTE "<<="
@@ -165,7 +176,7 @@ const struct hdql_Compound * hdql_parser_top_compound(struct Workspace *);
 %token<fltStaticValue> T_FLT_STATIC_VALUE "floating point value"
 
 %type<queryPtr> queryExpr aOp aQExpr;
-%type<vCompound> vCompoundDef scopedDefs;
+%type<vCompound> vCompoundDef vPositionalCompoundDef vNamedCompoundDef scopedDefs;
 %type<funcArgsList> argsList;
 %type<annotatedSelection> selection;
 //%type<selectionBinOp> selExpr;
@@ -566,57 +577,42 @@ scopedDefs : vCompoundDef {
            }
            ;
 
-vCompoundDef : T_IDENTIFIER T_WALRUS aQExpr {
-                /* _substitute_ compound with new virtual one */
-                struct hdql_Compound * vCompound
-                            = hdql_virtual_compound_new(hdql_parser_top_compound(ws), ws->context);
-                hdql_context_add_virtual_compound(ws->context, vCompound);
-                assert(hdql_compound_is_virtual(vCompound));
-                /* define new attribute of a virtual compound,
-                 * named as T_IDENTIFIER with query as a result.
-                 * New (virtual) attribute definition inherits what is
-                 * provided by query's top attribute */
-                struct hdql_AttrDef * newAttrDef
-                    = hdql_attr_def_create_fwd_query($3, ws->context);
-                /* Add new attribute to virtual compound */
-                int rc = hdql_compound_add_attr(vCompound, $1, newAttrDef);
-                if(0 != rc) {
-                    hdql_error(&yyloc, ws, yyscanner
-                        , "failed to define attribute \"%s\" for virtual"
-                          " compound type based on `%s'; error code %d"
-                        , $1
-                        , hdql_compound_get_name(hdql_virtual_compound_get_parent(vCompound))
-                        , rc );
-                    free($1);
-                    return HDQL_BAD_QUERY_EXPRESSION;
-                }
-                free($1);
-                $$.compoundPtr = vCompound;
+vCompoundDef : vNamedCompoundDef
+             | vPositionalCompoundDef
+             ;
+
+vNamedCompoundDef : T_IDENTIFIER T_WALRUS aQExpr {
+                struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, $1, $3);
+                if(!nvc) { free($1); return HDQL_BAD_QUERY_EXPRESSION; }
+                $$.compoundPtr = nvc;
             }
-            | vCompoundDef T_COMMA {
+            | vNamedCompoundDef T_COMMA {
                 ws->compoundStack[ws->compoundStackTop].compoundPtr = $1.compoundPtr;
             } T_IDENTIFIER T_WALRUS aQExpr {
-                assert(hdql_compound_is_virtual($1.compoundPtr));
-                /* define new attribute of a virtual compound,
-                 * named as T_IDENTIFIER with query as a result.
-                 * New (virtual) attribute definition inherits what is
-                 * provided by query's top attribute */
-                struct hdql_AttrDef * newAttrDef
-                    = hdql_attr_def_create_fwd_query($6, ws->context);
-                /* Add new attribute to virtual compound */
-                int rc = hdql_compound_add_attr($1.compoundPtr, $4, newAttrDef);
-                if(0 != rc) {
-                    hdql_error(&yyloc, ws, yyscanner
-                        , "failed to define attribute \"%s\" for virtual"
-                          " compound type based on `%s'; error code %d"
-                        , $4
-                        , hdql_compound_get_name(hdql_virtual_compound_get_parent($1.compoundPtr))
-                        , rc );
-                    free($4);
-                    return HDQL_BAD_QUERY_EXPRESSION;
-                }
-                free($4);
-                $$.compoundPtr = $1.compoundPtr;
+                struct hdql_Compound * vc = _vcompound_append_with_query(&yyloc, ws, yyscanner
+                            , $1.compoundPtr, $4, $6);
+                if(!vc) { free($4); return HDQL_BAD_QUERY_EXPRESSION; }
+                $$.compoundPtr = vc;
+            }
+            ;
+
+vPositionalCompoundDef : aQExpr {
+                char * attrName = strdup("#1");
+                struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, attrName, $1);
+                if(!nvc) { free(attrName); return HDQL_BAD_QUERY_EXPRESSION; }
+                ws->posCompoundNArg = 2;
+                $$.compoundPtr = nvc;
+            }
+            | vPositionalCompoundDef T_COMMA {
+                ws->compoundStack[ws->compoundStackTop].compoundPtr = $1.compoundPtr;
+            } aQExpr {
+                char bf[32];
+                snprintf(bf, sizeof(bf), "#%u", ws->posCompoundNArg++);
+                char * attrName = strdup(bf);
+                struct hdql_Compound * vc = _vcompound_append_with_query(&yyloc, ws, yyscanner
+                            , $1.compoundPtr, attrName, $4);
+                if(!vc) { free(attrName); return HDQL_BAD_QUERY_EXPRESSION; }
+                $$.compoundPtr = vc;
             }
             ;
 
@@ -999,6 +995,45 @@ _new_function( YYLTYPE * yyloc, struct Workspace * ws, yyscan_t yyscanner
     hdql_query_set_transient_subject_ownership(q);
     return q;
 }  /* _new_function() */
+
+/*
+ * Virtual compound definitons
+ */
+
+static struct hdql_Compound *
+_vcompound_append_with_query(YYLTYPE * yyloc, struct Workspace * ws, yyscan_t yyscanner
+            , struct hdql_Compound * vCompound
+            , char * attrName, struct hdql_Query * q
+            ) {
+    assert(hdql_compound_is_virtual(vCompound));
+    /* define new attribute of a virtual compound,
+     * named as T_IDENTIFIER with query as a result.
+     * New (virtual) attribute definition inherits what is
+     * provided by query's top attribute */
+    struct hdql_AttrDef * newAttrDef
+        = hdql_attr_def_create_fwd_query(q, ws->context);
+    /* Add new attribute to virtual compound */
+    int rc = hdql_compound_add_attr(vCompound, attrName, newAttrDef);
+    if(0 == rc) return vCompound;
+    hdql_error(yyloc, ws, yyscanner
+        , "failed to define attribute \"%s\" for virtual"
+          " compound type based on `%s'; error code %d"
+        , attrName
+        , hdql_compound_get_name(hdql_virtual_compound_get_parent(vCompound))
+        , rc );
+    return NULL;
+}
+
+static struct hdql_Compound *
+_vcompound_def_start(YYLTYPE * yyloc, struct Workspace * ws, yyscan_t yyscanner
+        , char * attrName, struct hdql_Query * firstQuery
+        ) {
+    /* _substitute_ compound with new virtual one */
+    struct hdql_Compound * vCompound
+                = hdql_virtual_compound_new(hdql_parser_top_compound(ws), ws->context);
+    hdql_context_add_virtual_compound(ws->context, vCompound);
+    return _vcompound_append_with_query(yyloc, ws, yyscanner, vCompound, attrName, firstQuery);
+}
 
 /* 
  * Main parser function

--- a/hdql.y
+++ b/hdql.y
@@ -21,10 +21,10 @@ struct hdql_AnnotatedSelection {
 typedef struct Workspace {
     struct {
         const struct hdql_Compound * compoundPtr;
-        char * newAttributeName;
+        char * newAttributeName;  /* XXX, unused */
+        unsigned int posCompoundNArg;
     } compoundStack[HDQL_COMPOUNDS_STACK_MAX_DEPTH];
     unsigned char compoundStackTop;
-    unsigned int posCompoundNArg;
     struct hdql_Context * context;
     struct hdql_Query * query;
     /* shortcuts */
@@ -587,6 +587,10 @@ vNamedCompoundDef : T_IDENTIFIER T_WALRUS aQExpr {
                 $$.compoundPtr = nvc;
             }
             | vNamedCompoundDef T_COMMA {
+                /* TODO: forgot, why we needed mid-rule action here. This is
+                 * porably related to define nested v-compounds, yet in principle,
+                 * compound stack push/pop should do this for us. See also same
+                 * note for vPositionalCompoundDef */
                 ws->compoundStack[ws->compoundStackTop].compoundPtr = $1.compoundPtr;
             } T_IDENTIFIER T_WALRUS aQExpr {
                 struct hdql_Compound * vc = _vcompound_append_with_query(&yyloc, ws, yyscanner
@@ -600,14 +604,15 @@ vPositionalCompoundDef : aQExpr {
                 char * attrName = strdup("#1");
                 struct hdql_Compound * nvc = _vcompound_def_start(&yyloc, ws, yyscanner, attrName, $1);
                 if(!nvc) { free(attrName); return HDQL_BAD_QUERY_EXPRESSION; }
-                ws->posCompoundNArg = 2;
+                ws->compoundStack[ws->compoundStackTop].posCompoundNArg = 2;
                 $$.compoundPtr = nvc;
             }
             | vPositionalCompoundDef T_COMMA {
+                /* TODO: see same example for vNamedCompoundDef */
                 ws->compoundStack[ws->compoundStackTop].compoundPtr = $1.compoundPtr;
             } aQExpr {
                 char bf[32];
-                snprintf(bf, sizeof(bf), "#%u", ws->posCompoundNArg++);
+                snprintf(bf, sizeof(bf), "#%u", ws->compoundStack[ws->compoundStackTop].posCompoundNArg++);
                 char * attrName = strdup(bf);
                 struct hdql_Compound * vc = _vcompound_append_with_query(&yyloc, ws, yyscanner
                             , $1.compoundPtr, attrName, $4);
@@ -750,10 +755,12 @@ static void _transient_dtr__virtual_compound(hdql_Datum_t q_, hdql_Context_t ctx
  *  
  * up to the closing `}' virtual compound has been composed already, we shall
  * provide the parser with query node attributed to this v-compound in order
- * it will be capable to resolve `.e'. Note, this query is always a scalar
- * instance (there is no way in HDQL currently to "split" single instance into
- * a collection of items within the "scope operator"). This scalar is optional
- * as filtering expression can result of the instance to be declined. */
+ * it will be capable to resolve `.e'.
+ *
+ * XXX Note, this query is always a scalar
+ * XXX instance (there is no way in HDQL currently to "split" single instance into
+ * XXX a collection of items within the "scope operator"). This scalar is optional
+ * XXX as filtering expression can result of the instance to be declined. */
 static struct hdql_Query *
 _new_virtual_compound_query( YYLTYPE * yylloc
                            , Workspace_t ws
@@ -761,21 +768,41 @@ _new_virtual_compound_query( YYLTYPE * yylloc
                            , struct hdql_Compound * vCompoundPtr
                            , struct hdql_Query * filterQuery
                            ) {
-    struct hdql_ScalarAttrInterface iface;
-    if(NULL == filterQuery) {
-        bzero(&iface, sizeof(iface));
-        iface.dereference = _trivial_dereference;
-    } else {
-        iface = _hdql_gFilteredCompoundIFace;
-        iface.definitionData = (hdql_Datum_t) filterQuery;
-    }
-    struct hdql_AttrDef * vCompoundAttrDef = hdql_attr_def_create_compound_scalar(
+    struct hdql_AttrDef * vCompoundAttrDef;
+    #if 1
+        struct hdql_ScalarAttrInterface iface;
+        if(NULL == filterQuery) {
+            bzero(&iface, sizeof(iface));
+            iface.dereference = _trivial_dereference;
+        } else {
+            iface = _hdql_gFilteredCompoundIFace;
+            iface.definitionData = (hdql_Datum_t) filterQuery;
+        }
+        vCompoundAttrDef = hdql_attr_def_create_compound_scalar(
                   vCompoundPtr  /* ... compound ptr */
                 , &iface  /* ......... scalar iface ptr */
                 , 0x0  /* ............ key type code */
                 , NULL  /* ........... key copy callback */
                 , ws->context  /* .... context */
                 );
+    #else
+        struct hdql_CollectionAttrInterface iface;
+        if(NULL == filterQuery) {
+            bzero(&iface, sizeof(iface));
+            iface.dereference = _trivial_dereference;
+        } else {
+            iface = ;  // TODO
+            iface.definitionData = (hdql_Datum_t) filterQuery;
+        }
+        vCompoundAttrDef = hdql_attr_def_create_compound_collection(
+                  vCompoundPtr  /* ... compound ptr */
+                , &iface  /* ......... scalar iface ptr */
+                , 0x0  /* ............ key type code */
+                , NULL  /* ........... key copy callback */
+                , ws->context  /* .... context */
+                );
+        // ...
+    #endif
     if(NULL == filterQuery) {
         hdql_attr_def_set_transient(vCompoundAttrDef, NULL);
     } else {

--- a/include/hdql/attr-def.h
+++ b/include/hdql/attr-def.h
@@ -53,10 +53,11 @@ struct hdql_ScalarAttrInterface {
                    );
 };
 
-/**\brief Keys list allocation callback
+/**\brief Collection keys list allocation callback
  *
  * Although keys are explicitly typed, their length can depend on the
- * definition data for synthetic definitions (composed during compilation).
+ * definition data for synthetic definitions (composed during compilation --
+ * forwarding queries, bound attributes, etc).
  * This callback is used to allocate key lists when key type code is not set.
  * */
 typedef struct hdql_CollectionKey * (*hdql_ReserveKeysListCallback_t)(
@@ -73,8 +74,8 @@ struct hdql_CollectionAttrInterface {
                                     , hdql_SelectionArgs_t
                                     , hdql_Context_t
                                     );
-    /** Should dereference iterator object AND return NULL if it is not
-     * possible (no items available) */
+    /**\brief Dereferences iterator object, returning NULL if it is not
+     *        possible (no items available) */
     hdql_Datum_t   (*dereference)   ( hdql_It_t
                                     , struct hdql_CollectionKey *
                                     );
@@ -150,10 +151,31 @@ hdql_attr_def_create_compound_collection(
         , hdql_Context_t
         );
 
+/**\brief Create attribute definition forwarding to a query 
+ *
+ * This kind of attribute definitions created within virtual (transient)
+ * compounds in the expressions like `{h:=.hits}` (here `h` is the attribute
+ * forwarding query). I.e. forwarding attributes are just aliases, in the
+ * context of virtual compounds. */
 struct hdql_AttrDef *
 hdql_attr_def_create_fwd_query(
           struct hdql_Query * subquery
         , hdql_Context_t
+        , int * rc
+        );
+
+/**\brief Create definition bound to a query
+ *
+ * Attribute definition created here are bound to a query result managed
+ * externally in the expressions like `{h:=*.hits}` (here `h` is the bound
+ * attribute), typically within a Cartesian product within the virtual
+ * (transient) compound. In this case such AD behaves like a pivot, creating
+ * new virtual compound item per every item in the underlying subquery. */
+struct hdql_AttrDef *
+hdql_attr_def_create_bound(
+          struct hdql_Query * subquery
+        , hdql_Context_t context
+        , int * rc
         );
 
 struct hdql_AttrDef *
@@ -196,6 +218,7 @@ bool hdql_attr_def_is_fwd_query(hdql_AttrDef_t);
 bool hdql_attr_def_is_direct_query(hdql_AttrDef_t);
 bool hdql_attr_def_is_static_value(hdql_AttrDef_t);
 bool hdql_attr_def_is_transient(hdql_AttrDef_t);
+bool hdql_attr_def_is_bound(hdql_AttrDef_t);
 
 /**\brief Returns type code for (optionally static) atomic value */
 hdql_ValueTypeCode_t
@@ -234,7 +257,10 @@ const hdql_AttrDef_t hdql_attr_def_top_attr(const hdql_AttrDef_t);
 
 void hdql_attr_def_destroy(hdql_AttrDef_t, hdql_Context_t);
 
-/**\brief Prints short one-line string describing attribute definition */
+/**\brief Puts short one-line string describing attribute definition into strbuf
+ *
+ * Named `top_attr_str` to reflect the fact that it will resolve forwarding
+ * queries, not just print plain AD (yet can be used for that). */
 int
 hdql_top_attr_str( const struct hdql_AttrDef * subj
               , char * strbuf, size_t buflen

--- a/include/hdql/compound.h
+++ b/include/hdql/compound.h
@@ -36,6 +36,9 @@ const struct hdql_Compound * hdql_virtual_compound_get_parent(const struct hdql_
 /**\brief Returns true if compound is virtual */
 int hdql_compound_is_virtual(const struct hdql_Compound * compound);
 
+/**\brief Returns true if virtual compound is bound */
+bool hdql_virtual_compound_is_bound(const struct hdql_Compound * compound);
+
 /**\brief Returns true if both compounds are of the same type */
 bool hdql_compound_is_same(const struct hdql_Compound * compoundA, const struct hdql_Compound * compoundB);
 

--- a/include/hdql/compound.h
+++ b/include/hdql/compound.h
@@ -114,6 +114,18 @@ void hdql_compound_get_attr_names(const struct hdql_Compound * c, const char ** 
  * */
 void hdql_compound_get_attr_names_recursive(const struct hdql_Compound * c, const char ** dest);
 
+/*\brief Iterates over all attributes within a compound with a callback
+ *
+ * Provided callback should return 0 to proceed iteration, otherwise loop
+ * stops.
+ *
+ * \returns number of attributes iterated.
+ * */
+size_t
+hdql_compound_for_each_own_attribute(const struct hdql_Compound * C
+        , int (*cllb)(const char *, size_t, const struct hdql_AttrDef *, void *)
+        , void * userdata);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/include/hdql/errors.h
+++ b/include/hdql/errors.h
@@ -23,6 +23,7 @@
 #define HDQL_ERR_ATTR_FILTER              -16   /* filter can not be applied to result query of type */
 #define HDQL_ERR_FILTER_RET_TYPE          -17   /* filter query result type can not be evaluated to bool */
 #define HDQL_ERR_BAD_QUERY_STATE          -18   /* query instance is on unforeseen state */
+#define HDQL_ERR_NOT_A_COLLECTION         -19   /* query results in a scalar, collection expected */
 /* Arithmetic operations (definition or evaluation) errors */
 #define HDQL_ERR_OPERATION_NOT_SUPPORTED  -21   /* operation is not supported */
 #define HDQL_ERR_ARITH_OPERATION          -22   /* arithmetic operation error */

--- a/include/hdql/function.h
+++ b/include/hdql/function.h
@@ -32,8 +32,10 @@ struct hdql_Functions;
 /**\brief Constructor instantiating function object for given queries 
  *
  * Shall return either a pointer to attribute definition performing certain
- * function call, or a null pointer. In the latter case, may set a message
- * in the given buffer explaining why failure reason. */
+ * function call, or a null pointer when this is not possible. In the latter
+ * case, may set a message in the given buffer explaining failure
+ * reason (legitimate way to deny function instantiation for overridden
+ * functions). */
 typedef struct hdql_AttrDef * (*hdql_FunctionConstructor_t)(
           struct hdql_Query ** args, void * userdata
         , char * failureBuffer
@@ -60,11 +62,21 @@ hdql_functions_resolve( struct hdql_Functions * funcDict
 int
 hdql_functions_add_standard_math(struct hdql_Functions * functions);
 
-#if 0
-
 /*
  * Some common implementations
  */
+
+/**\brief Cartesian product function
+ *
+ * Results in a virtual compound with sub-queries matching exactly their
+ * collections
+ * */
+//struct hdql_AttrDef *
+//hdql_func_helper__try_instantiate_cartesian_product(struct hdql_Query **, void *
+//        , char * errbf, size_t errbfSize
+//        , hdql_Context_t);
+
+#if 0
 
 /**\brief Common constructor for single-argument math functions
  *

--- a/include/hdql/helpers/functions.hh
+++ b/include/hdql/helpers/functions.hh
@@ -65,11 +65,11 @@ apply(RetT (*pf)(ArgsT...), struct hdql_Datum ** args) {
  *
  * Automatic implementation provided by this template is restricted with
  * following rules:
- *  - Number of arguments must be known
+ *  - Number of arguments must be fixed;
  *  - Considered C/C++ function should map N (N > 0) arguments of scalar atomic
- *    or non-virtual scalars into a scalar or non-virtual compound
+ *    or non-virtual scalars into a scalar or non-virtual compound.
  * Despite this is rather wide class of C/C++ functions (e.g. all maths,
- * trigonometric, etc), thisimplementation can be somewhat restrictive as it
+ * trigonometric, etc), this implementation can be somewhat restrictive as it
  * does not support variadic arguments, virtual compounds, etc.
  * */
 template<typename ResultT, typename ...ArgsT >

--- a/include/hdql/internal-ifaces.h
+++ b/include/hdql/internal-ifaces.h
@@ -64,7 +64,10 @@ hdql_Datum_t hdql_bound_compound_collection_interface_definition_data_init(
             , struct hdql_Query * filterQuery
             , hdql_Context_t context
         );
+
 void hdql_bound_compound_collection_interface_definition_data_destroy(hdql_Datum_t d, hdql_Context_t ctx);
+
+struct hdql_CollectionKey * hdql_bound_compound_key_reserve(const hdql_Datum_t defData_, hdql_Context_t ctx);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/hdql/internal-ifaces.h
+++ b/include/hdql/internal-ifaces.h
@@ -1,18 +1,27 @@
 #ifndef H_HDQL_INTERNAL_INTERFACE_IMPLEMS_H
-#define H_HDQL_INTERNAL_INTERFACE_IMPLEMS_H
+#define H_HDQL_INTERNAL_INTERFACE_IMPLEMS_H 1
 
+#include "hdql/types.h"
 #include "hdql/attr-def.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/* 
+ * Forwarding queries
+ * */
 
-
+/** Interface for queries evaluation to attributes to scalar forwarding queries */
 extern const struct hdql_ScalarAttrInterface        _hdql_gScalarFwdQueryIFace;
+/** Interface for forwarding queries iterating over collections */
 extern const struct hdql_CollectionAttrInterface    _hdql_gCollectionFwdQueryIFace;
 
-/**\brief Definition data for arithmetic operation access interfaces*/
+/*
+ * Binary arithmetic operations
+ * */
+
+/** Definition data for arithmetic operation access interfaces*/
 struct hdql_ArithOpDefData {
     struct hdql_Query * args[2];
     const struct hdql_OperationEvaluator * evaluator;
@@ -24,7 +33,38 @@ extern const struct hdql_CollectionAttrInterface    _hdql_gCollectionArithOpIFac
 struct hdql_CollectionKey *
 hdql_reserve_arith_op_collection_key(const hdql_Datum_t defData, hdql_Context_t context);
 
+/*
+ * Filtered compound collection
+ **/
+
 extern const struct hdql_ScalarAttrInterface _hdql_gFilteredCompoundIFace;
+
+/*
+ * Binding queries, bound attributes and bound compound interface
+ **/
+
+/** Attribute, bound to a query (to be finalized with definition data) */
+extern const struct hdql_ScalarAttrInterface        _hdql_gBoundQueryIFace;
+/** Returns new instance of bound value interface's definition data */
+hdql_Datum_t hdql_bound_value_interface_definition_data_init(struct hdql_Query *, hdql_Context_t);
+/** Destroys instance of bound value interface's definition data */
+void hdql_bound_value_interface_definition_data_destroy(hdql_Datum_t d, hdql_Context_t ctx);
+
+/** Interface to a collection of bound compounds */
+extern const struct hdql_CollectionAttrInterface    _hdql_gBindingCompoundCollectionIFace;
+/** Definition data for `_hdql_gBindingCompoundCollectionIFace` */
+struct hdql_BindingCompoundCollectionDefData {
+    struct hdql_Compound * vCompound;  /* has to have at least one bound attribute */
+    struct hdql_Query * filterQuery;  /* optional */
+};
+
+/** Instantiates bound compound collection definition data */
+hdql_Datum_t hdql_bound_compound_collection_interface_definition_data_init(
+              struct hdql_Compound * vCompound
+            , struct hdql_Query * filterQuery
+            , hdql_Context_t context
+        );
+void hdql_bound_compound_collection_interface_definition_data_destroy(hdql_Datum_t d, hdql_Context_t ctx);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/hdql/query-key.h
+++ b/include/hdql/query-key.h
@@ -7,27 +7,40 @@
 extern "C" {
 #endif
 
+/**\brief Identifies an element within a collection */
 struct hdql_CollectionKey {
-    /**\brief Collection key type
+    /**\brief Collection key type code
      *
      * HDQL manages key instance lifecycle, so key must be one of the
      * registered types.
      *
      * Zero code is reserved for empty key placeholders and key lists. */
     hdql_ValueTypeCode_t code:HDQL_VALUE_TYPEDEF_CODE_BITSIZE;
-    hdql_ValueTypeCode_t isList:1;
-    hdql_ValueTypeCode_t isTerminal:1;
-    /**\brief Ptr to actual key value */
+    hdql_ValueTypeCode_t isList:1;  /**< how to interpret payload */
+    hdql_ValueTypeCode_t isTerminal:1;  /**< marks last key in list when `isList` */
+    /**\brief Collection key item payload */
     union {
+        /**\brief Actual datum of the key when it is not a list */
         hdql_Datum_t datum;
+        /**\brief Array of keys
+         *
+         * Used only when `isList` is set. Sequence must be terminated with
+         * item with `isTerminal` set. */
         struct hdql_CollectionKey * keysList;
     } pl;
-    /**\brief Some keys may have a string label assigned*/
+    /**\brief Key may have a string label assigned */
     const char * label;
 };
 
 
-/**\brief Reserves keys for the query */
+/**\brief Reserves keys for the query
+ *
+ * \note This function reserves an entire key chain and must be called
+ *       on pre-allocated array of keys.
+ *
+ * \todo To avoid confusion, rename it, implement more consistent
+ *       key-allocation logic, see #14
+ * */
 int
 hdql_query_keys_reserve( struct hdql_Query * query
                        , struct hdql_CollectionKey ** keys

--- a/src/attr-def.c
+++ b/src/attr-def.c
@@ -371,6 +371,7 @@ hdql_attr_def_create_static_atomic_scalar_value(
     return ad;
 }
 
+
 struct hdql_AttrDef *
 hdql_attr_def_create_bound(
           struct hdql_Query * subquery
@@ -398,7 +399,7 @@ hdql_attr_def_create_bound(
     /* always transient (TODO: implement dtr) */
     ad->isTransient = 0x1;
     ad->transient_dtr = NULL;  /* TODO: dtr should delete def data */
-    /* has no key (TODO: verify) */
+    /* attribute has no key  */
     ad->keyTypeCode = 0x0;
     ad->reserveKeys = NULL;
     /* inherit type info as is */
@@ -556,6 +557,8 @@ hdql_attr_def_reserve_keys( const hdql_AttrDef_t ad
                              ); 
         if(NULL == key->pl.keysList) return -1;
         key->isList = 0x1;
+        /* ^^^ we're in scalar AD, why do we assign a list flag here?!
+         *     this is sick... see issue #14 */
         return 0;
     }
     assert(0);  /* bad interface definition -- not a collection, nor a scalar */

--- a/src/attr-def.c
+++ b/src/attr-def.c
@@ -371,6 +371,9 @@ hdql_attr_def_create_static_atomic_scalar_value(
     return ad;
 }
 
+static void _transient_dtr__binding_query(hdql_Datum_t d, hdql_Context_t ctx) {
+    hdql_bound_value_interface_definition_data_destroy(d, ctx);
+}
 
 struct hdql_AttrDef *
 hdql_attr_def_create_bound(
@@ -394,11 +397,13 @@ hdql_attr_def_create_bound(
     ad->isAtomic = qTopAD->isAtomic;
     /* result is always a scalar */
     ad->isCollection = 0x0;
+    /* bound is NOT forwarding */
+    ad->isFwdQuery = 0x0;
     /* static value is inherited (TODO: verify) */
     ad->staticValueFlags = qTopAD->staticValueFlags;
-    /* always transient (TODO: implement dtr) */
+    /* always transient */
     ad->isTransient = 0x1;
-    ad->transient_dtr = NULL;  /* TODO: dtr should delete def data */
+    ad->transient_dtr = _transient_dtr__binding_query;
     /* attribute has no key  */
     ad->keyTypeCode = 0x0;
     ad->reserveKeys = NULL;

--- a/src/attr-def.c
+++ b/src/attr-def.c
@@ -265,6 +265,7 @@ _hdql_reserve_keys_list_for_fwd_query(
 }
 
 static void _transient_dtr__fwd_query(hdql_Datum_t d, hdql_Context_t ctx) {
+    /* TODO: bound queries are special */
     if(d) {
         hdql_query_destroy((struct hdql_Query *) d, ctx);
     }
@@ -274,10 +275,19 @@ struct hdql_AttrDef *
 hdql_attr_def_create_fwd_query(
           struct hdql_Query * subquery
         , hdql_Context_t context
+        , int * rc
         ) {
+    assert(rc);
     struct hdql_AttrDef * ad = hdql_alloc(context, struct hdql_AttrDef);
+    if(!ad) {
+        *rc = HDQL_ERR_MEMORY;
+        return NULL;
+    }
     const struct hdql_AttrDef * fwdAD = hdql_query_top_attr(subquery);
     bool isFullyScalar = hdql_query_is_fully_scalar(subquery);
+    /* ^^^ here we check here the full chain and consider
+     *     fwd query as a scalar only if all the chained queries results in
+     *     a scalar values */
 
     bzero((void*) ad, sizeof(struct hdql_AttrDef));
 
@@ -285,9 +295,6 @@ hdql_attr_def_create_fwd_query(
      * query is supposed to fetch */
     ad->isAtomic         = hdql_attr_def_is_atomic(fwdAD) ? 0x1 : 0x0;
     ad->isCollection     = isFullyScalar ? 0x0 : 0x1;
-    /* ^^^ we check here the full chain and consider
-     *     fwd query as a scalar only if all the chained queries results in
-     *     a scalar values */
     
     ad->isFwdQuery       = 0x1;
     ad->staticValueFlags = 0x0;
@@ -300,6 +307,7 @@ hdql_attr_def_create_fwd_query(
         ad->interface.collection = _hdql_gCollectionFwdQueryIFace;
         ad->interface.collection.definitionData = (hdql_Datum_t) subquery;
     }
+
     hdql_attr_def_set_transient(ad, _transient_dtr__fwd_query);
 
     ad->keyTypeCode = 0x0;
@@ -307,7 +315,6 @@ hdql_attr_def_create_fwd_query(
 
     return ad;
 }
-
 
 static hdql_Datum_t
 _static_atomic_scalar_dereference( hdql_Datum_t root
@@ -364,6 +371,46 @@ hdql_attr_def_create_static_atomic_scalar_value(
     return ad;
 }
 
+struct hdql_AttrDef *
+hdql_attr_def_create_bound(
+          struct hdql_Query * subquery
+        , hdql_Context_t context
+        , int * rc
+        ) {
+    assert(!hdql_query_is_fully_scalar(subquery));
+    *rc = 0;
+    const struct hdql_AttrDef * qTopAD = hdql_query_top_attr(subquery);
+    assert(qTopAD);
+    /* Bound attribute addresses external value provided by the query which is
+     * managed outside the compound this request is applied to. */
+    struct hdql_AttrDef * ad = hdql_alloc(context, struct hdql_AttrDef);
+    if(!ad) {
+        *rc = HDQL_ERR_MEMORY;
+        return NULL;
+    }
+
+    /* `is-atomic' prop is inherited */
+    ad->isAtomic = qTopAD->isAtomic;
+    /* result is always a scalar */
+    ad->isCollection = 0x0;
+    /* static value is inherited (TODO: verify) */
+    ad->staticValueFlags = qTopAD->staticValueFlags;
+    /* always transient (TODO: implement dtr) */
+    ad->isTransient = 0x1;
+    ad->transient_dtr = NULL;  /* TODO: dtr should delete def data */
+    /* has no key (TODO: verify) */
+    ad->keyTypeCode = 0x0;
+    ad->reserveKeys = NULL;
+    /* inherit type info as is */
+    memcpy(&ad->typeInfo, &qTopAD->typeInfo, sizeof(qTopAD->typeInfo));
+
+    /* set interface to bound shim, initialized with query */
+    ad->interface.scalar = _hdql_gBoundQueryIFace;
+    ad->interface.scalar.definitionData
+        = hdql_bound_value_interface_definition_data_init(subquery, context);
+    
+    return ad;
+}
 
 struct hdql_AttrDef *
 hdql_attr_def_create_dynamic_value(
@@ -403,6 +450,20 @@ bool hdql_attr_def_is_fwd_query(hdql_AttrDef_t ad) { return ad->isFwdQuery; }
 bool hdql_attr_def_is_direct_query(hdql_AttrDef_t ad) { return !ad->isFwdQuery; }
 bool hdql_attr_def_is_static_value(hdql_AttrDef_t ad) { return ad->staticValueFlags; }
 bool hdql_attr_def_is_transient(hdql_AttrDef_t ad) { return ad->isTransient; }
+
+bool hdql_attr_def_is_bound(hdql_AttrDef_t ad) {
+    if(!hdql_attr_def_is_scalar(ad)) return false;
+    /* ^^^ we do not have such thing as collection of collections in HDQL */
+    const struct hdql_ScalarAttrInterface * iface = hdql_attr_def_scalar_iface(ad);
+    /* TODO: can we have something more elegant than this here? */
+    if( iface->destroy == _hdql_gBoundQueryIFace.destroy ) {
+        assert(iface->instantiate == _hdql_gBoundQueryIFace.instantiate );
+        assert(iface->dereference == _hdql_gBoundQueryIFace.dereference );
+        assert(iface->reset       == _hdql_gBoundQueryIFace.reset       );
+        return true;
+    }
+    return false;
+}
 
 hdql_ValueTypeCode_t
 hdql_attr_def_get_atomic_value_type_code(const hdql_AttrDef_t ad) {

--- a/src/compound.cc
+++ b/src/compound.cc
@@ -224,3 +224,23 @@ hdql_compound_destroy(hdql_Compound * compound, hdql_Context_t context) {
     #endif
 }
 
+extern "C" size_t
+hdql_compound_for_each_own_attribute(const struct hdql_Compound * C
+        , int (*cllb)(const char *, size_t, const struct hdql_AttrDef *, void *)
+        , void * userdata) {
+    const size_t nAttrsOverall = hdql_compound_get_nattrs(C);
+    const char ** names = (const char **) alloca(sizeof(char*)*nAttrsOverall);
+    hdql_compound_get_attr_names(C, names);
+    size_t nBindingQueries = 0;
+    for(size_t nAttr = 0; nAttr < nAttrsOverall; ++nAttr) {
+        const struct hdql_AttrDef * attrAD = hdql_compound_get_attr(C, names[nAttr]);
+        if(!hdql_attr_def_is_bound(attrAD)) continue;
+        ++nBindingQueries;
+        if(cllb ) {
+            int rc = cllb(names[nAttr], nBindingQueries, attrAD, userdata);
+            if(0 != rc) return nBindingQueries;
+        }
+    }
+    return nBindingQueries;
+}
+

--- a/src/compound.cc
+++ b/src/compound.cc
@@ -61,7 +61,7 @@ hdql_virtual_compound_new(const hdql_Compound * parent, struct hdql_Context * ct
 extern "C" void
 hdql_virtual_compound_destroy(hdql_Compound * vCompound, struct hdql_Context * ctx) {
     for(auto & attrDef : vCompound->attrsByName ) {
-        if(hdql_attr_def_is_fwd_query(attrDef.second))
+        if(hdql_attr_def_is_transient(attrDef.second))
             hdql_attr_def_destroy(attrDef.second, ctx);
     }
     #ifdef HDQL_CONTEXT_BASED_COMPOUNDS_CREATION

--- a/src/compound.cc
+++ b/src/compound.cc
@@ -78,6 +78,15 @@ hdql_compound_is_virtual(const hdql_Compound * compound) {
 }
 
 extern "C" bool
+hdql_virtual_compound_is_bound(const struct hdql_Compound * compound) {
+    for(auto & attrDef : compound->attrsByName ) {
+        if(hdql_attr_def_is_bound(attrDef.second))
+            return true;
+    }
+    return false;
+}
+
+extern "C" bool
 hdql_compound_is_same(const struct hdql_Compound * compoundA
         , const struct hdql_Compound * compoundB) {
     /* todo: reserved for further (possible) elaboration */

--- a/src/context.cc
+++ b/src/context.cc
@@ -14,8 +14,6 @@
 #include <cstdarg>
 #include <unordered_map>
 
-#include <iostream>  // XXX
-
 // These functions are not defined in public headers, but still implemented
 
 // from src/values.cc:

--- a/src/errors.c
+++ b/src/errors.c
@@ -29,6 +29,8 @@ hdql_err_str(hdql_Err_t code) {
             return "filter query result type can not be evaluated to bool";
         case HDQL_ERR_BAD_QUERY_STATE:
             return "query instance is on unforeseen state";
+        case HDQL_ERR_NOT_A_COLLECTION:
+            return "query results in a scalar, collection expected";
 
         case HDQL_ERR_OPERATION_NOT_SUPPORTED:
             return "operation is not supported";

--- a/src/ifaces/arith-op-as-collection.c
+++ b/src/ifaces/arith-op-as-collection.c
@@ -65,6 +65,8 @@ _arith_op_collection_create( hdql_Datum_t owner
     bool bIsFullyScalar = state->defData->args[1] ? hdql_query_is_fully_scalar(state->defData->args[1]) : true;
     assert(aIsFullyScalar != bIsFullyScalar);  /* both scalars and both collections are prohibited */
     #endif
+    /* see comments to issue #14 -- we currently have to allocate and maintain
+     * keys unconditionally, but that must be changed in the future */
     if(!aIsFullyScalar) {
         /* first arg is collection */
         state->advance = _advance_a;

--- a/src/ifaces/bound-compound-collection.c
+++ b/src/ifaces/bound-compound-collection.c
@@ -1,0 +1,7 @@
+#include "hdql/attr-def.h"
+#include "hdql/query.h"
+#include "hdql/internal-ifaces.h"
+#include "hdql/types.h"
+
+#include <assert.h>
+

--- a/src/ifaces/bound-value.c
+++ b/src/ifaces/bound-value.c
@@ -1,0 +1,256 @@
+#include "hdql/attr-def.h"
+#include "hdql/compound.h"
+#include "hdql/context.h"
+#include "hdql/errors.h"
+#include "hdql/query-key.h"
+#include "hdql/query.h"
+#include "hdql/internal-ifaces.h"
+#include "hdql/types.h"
+
+#include <alloca.h>
+#include <assert.h>
+
+/* Bound value implements forwarded access interface over the object managed
+ * externally. Perculiar feature is that these iface has two stages in its
+ * lifecycle.
+ *
+ * - pointer to a query is stored in definition data, but it is not controlled
+ *   by this interface. It is stored *only* to be picked up at the end of
+ *   encompassing virtual compound creation (TODO: but gets deleted here?)
+ * - refers to a collection (sub-queries resulting in non-scalar item);
+ * - represents themself as a scalar during query state evaluation at own
+ *   level;
+ * - yet, the state is controlled by some other query implementing collection
+ *   interface.
+ *
+ * Example (lexic can differ):
+ *      .root.{one := .a, two := *.b.c}
+ *                               ^^^ this
+ * here `two' is the bound query and the encompassing `{}` virtual compound
+ * is a collection, steering iteration over bound query.
+ */
+
+/* NOTE: this is definition data, NOT AN ITERATOR! */
+struct BoundValueDefinitionData {
+    /* query that should provide the value. Set upon construction */
+    struct hdql_Query * q;
+    /* value pointer */
+    hdql_Datum_t * value;
+    /* ... key?*/
+};
+
+hdql_Datum_t
+hdql_bound_value_interface_definition_data_init(struct hdql_Query * q, hdql_Context_t ctx) {
+    struct BoundValueDefinitionData * d = (struct BoundValueDefinitionData *)
+            hdql_context_alloc(ctx, sizeof(struct BoundValueDefinitionData));
+    d->q = q;
+    d->value = NULL;
+    return (hdql_Datum_t) d;
+}
+
+void
+hdql_bound_value_interface_definition_data_destroy(hdql_Datum_t d, hdql_Context_t ctx) {
+    hdql_context_free(ctx, d);
+}
+
+/* Query is provided as `definitionData` */
+static hdql_Datum_t
+_bound_query_scalar_interface_instantiate(
+          hdql_Datum_t ownerDatum
+        , const hdql_Datum_t definitionData
+        , hdql_Context_t ctx
+        ) {
+    assert(definitionData);  /* otherwise, bound to what query/value? */
+    assert(((const struct BoundValueDefinitionData *) (definitionData))->value);
+    return *((const struct BoundValueDefinitionData *) (definitionData))->value;
+}
+
+static hdql_Datum_t
+_bound_query_scalar_interface_dereference(
+          hdql_Datum_t root
+        , hdql_Datum_t dd_
+        , struct hdql_CollectionKey * key  // can be null
+        , const hdql_Datum_t definitionData
+        , hdql_Context_t ctx
+        ) {
+    assert(definitionData);  /* otherwise, bound to what query/value? */
+    return *((const struct BoundValueDefinitionData *) (definitionData))->value;
+}
+
+static hdql_Datum_t
+_bound_query_scalar_interface_reset(
+          hdql_Datum_t newOwner
+        , hdql_Datum_t dd_
+        , const hdql_Datum_t definitionData
+        , hdql_Context_t ctx
+        ) {
+    assert(definitionData);  /* otherwise, bound to what query/value? */
+    return *((const struct BoundValueDefinitionData *) (definitionData))->value;
+}
+
+static void
+_bound_query_scalar_interface_destroy(
+          hdql_Datum_t dd_
+        , const hdql_Datum_t definitionData
+        , hdql_Context_t ctx
+        ) {
+    /* do nothing */
+}
+
+const struct hdql_ScalarAttrInterface _hdql_gBoundQueryIFace = {
+    .definitionData = NULL,  /* : changed in copies keep target forwarding query ptr */
+    .instantiate = _bound_query_scalar_interface_instantiate,
+    .dereference = _bound_query_scalar_interface_dereference,
+    .reset = _bound_query_scalar_interface_reset,
+    .destroy = _bound_query_scalar_interface_destroy
+};
+
+/* Bound compound collection (possibly filtered) manages Cartesian product
+ * internally to iterate over set of (binding) queries. 
+ *
+ * Upon creation the iterator gets initialized with compound containing (up to
+ * this point incomplete) bound attributes that are used to assemble data
+ * necessary for a Cartesian product.
+ * */
+
+struct QueryProdIterator {
+    struct hdql_Query * filterQuery;
+
+    struct hdql_Query ** boundQueries;
+    hdql_Datum_t * values;
+    struct hdql_CollectionKey ** keys;
+
+    hdql_Datum_t owner;
+    size_t nBindingQueries;
+    hdql_Context_t context;
+};
+
+static hdql_It_t
+_hdql_cartesian_product_as_collection_create( hdql_Datum_t owner
+                           , const hdql_Datum_t defData_
+                           , hdql_SelectionArgs_t selArgs_
+                           , hdql_Context_t ctx
+                           ) {
+    struct hdql_BindingCompoundCollectionDefData * dd
+            = hdql_cast(ctx, struct hdql_BindingCompoundCollectionDefData, defData_);
+    /* allocate definition data for transient interface */
+    struct QueryProdIterator * it = hdql_alloc(ctx, struct QueryProdIterator);
+
+    /*
+     * Init value interface and filtering
+     */
+
+
+
+    /*
+     * init Cartesian product
+     */
+
+    /* set filtering query (or NULL) */
+    it->filterQuery = dd->filterQuery;
+    /* populate bound queries refs for the attribute definition of
+     * binding compound. Once query for binding compound gets reset
+     * or advanced, the values get updated */
+    it->nBindingQueries = 0;
+    const size_t nAttrsOverall = hdql_compound_get_nattrs(dd->vCompound);
+    const char ** names = alloca(sizeof(char*)*nAttrsOverall);
+    hdql_compound_get_attr_names(dd->vCompound, names);
+    for(size_t nAttr = 0; nAttr < nAttrsOverall; ++nAttr) {
+        const struct hdql_AttrDef * attrAD = hdql_compound_get_attr(dd->vCompound, names[nAttr]);
+        if(hdql_attr_def_is_bound(attrAD)) ++(it->nBindingQueries);
+    }
+    assert(it->nBindingQueries > 0);  /* otherwise this compound could not be "bound" */
+
+    /* allocate arrays for queries, value ptrs, keys */
+    it->boundQueries = (struct hdql_Query **)
+            hdql_context_alloc(ctx
+                , it->nBindingQueries * sizeof(struct hdql_Query *));
+    it->values = (hdql_Datum_t *) hdql_context_alloc(ctx, sizeof(hdql_Datum_t *)*it->nBindingQueries);
+
+    size_t nBoundAttr = 0;
+    for(size_t nAttr = 0; nAttr < nAttrsOverall; ++nAttr) {
+        const struct hdql_AttrDef * attrAD = hdql_compound_get_attr(dd->vCompound, names[nAttr]);
+        if(!hdql_attr_def_is_bound(attrAD)) continue;
+        const struct hdql_ScalarAttrInterface * boundAttrIFace
+                = hdql_attr_def_scalar_iface(attrAD);
+        assert(boundAttrIFace->dereference == _hdql_gBoundQueryIFace.dereference);
+        /* ^^^ otherwise, how come it became a "bound attribute"? */
+        assert(boundAttrIFace->definitionData);
+        /* ^^^ otherwise, how this iface was instantiated?
+         * hdql_bound_value_interface_definition_data_init() must be used */
+        struct BoundValueDefinitionData * bDefData
+            = (struct BoundValueDefinitionData*) boundAttrIFace->definitionData;
+        it->boundQueries[nBoundAttr] = bDefData->q;
+        bDefData->value = it->values + nBoundAttr;
+        ++nBoundAttr;
+    }
+    printf( "XXX Cartesian product initialized to handle %zu bound attributes\n"
+          , it->nBindingQueries );
+    /* assign definition data to this transient interface */
+    return (hdql_It_t) it;
+}
+
+static hdql_Datum_t
+_hdql_cartesian_product_as_collection_dereference( hdql_It_t it_
+                                , struct hdql_CollectionKey * keyPtr
+                                ) {
+    struct QueryProdIterator * it = (struct QueryProdIterator *) it_;
+    return it->owner;
+}
+
+static hdql_It_t
+_hdql_cartesian_product_as_collection_advance( hdql_It_t it_ ) {
+    struct QueryProdIterator * it = (struct QueryProdIterator *) it_;
+    int rc = hdql_query_product_advance( it->boundQueries
+        , it->keys
+        , it->values
+        , it->owner
+        , it->nBindingQueries
+        , it->context
+        );
+    if(HDQL_ERR_CODE_OK != rc)
+        it->owner = NULL;
+    return it_;
+}
+
+static hdql_It_t
+_hdql_cartesian_product_as_collection_reset( hdql_It_t it_
+                          , hdql_Datum_t newOwner
+                          , const hdql_Datum_t defData
+                          , hdql_SelectionArgs_t selArgs
+                          , hdql_Context_t ctx
+                          ) {
+    assert(it_);
+    struct QueryProdIterator * it = (struct QueryProdIterator *) it_;
+    #ifndef NDEBUG
+    int rc =
+    #endif
+        hdql_query_product_reset( it->boundQueries
+        , it->keys
+        , it->values
+        , it->owner = newOwner
+        , it->nBindingQueries
+        , it->context = ctx
+        );
+    assert(0 == rc);  /* TODO we have no means to forward errors here */
+    return it_;
+}
+
+static void
+_hdql_cartesian_product_destroy( hdql_It_t it_
+                            , hdql_Context_t ctx
+                            ) {
+    // ...
+}
+
+
+const struct hdql_CollectionAttrInterface _hdql_gBindingCompoundCollectionIFace = {
+    .definitionData = NULL,  /* set by caller to the instance of `hdql_BoundCompoundDefinitionData` struct */
+    .create = _hdql_cartesian_product_as_collection_create,
+    .dereference =_hdql_cartesian_product_as_collection_dereference,
+    .advance = _hdql_cartesian_product_as_collection_advance,
+    .reset = _hdql_cartesian_product_as_collection_reset,
+    .destroy = _hdql_cartesian_product_destroy,
+    .compile_selection = NULL,  /* TODO? */
+    .free_selection = NULL  /*TODO?*/
+};

--- a/src/ifaces/bound-value.c
+++ b/src/ifaces/bound-value.c
@@ -6,6 +6,7 @@
 #include "hdql/query.h"
 #include "hdql/internal-ifaces.h"
 #include "hdql/types.h"
+#include "hdql/value.h"
 
 #include <alloca.h>
 #include <assert.h>
@@ -115,6 +116,9 @@ const struct hdql_ScalarAttrInterface _hdql_gBoundQueryIFace = {
 
 struct QueryProdIterator {
     struct hdql_Query * filterQuery;
+    const struct hdql_ValueInterface * filterVI;
+    hdql_Bool_t filterLogicResult;
+    hdql_TypeConverter toLogicFilterResultConverter;
 
     struct hdql_Query ** boundQueries;
     hdql_Datum_t * values;
@@ -183,7 +187,34 @@ _hdql_cartesian_product_as_collection_create( hdql_Datum_t owner
     struct QueryProdIterator * it = hdql_alloc(ctx, struct QueryProdIterator);
     it->context = ctx;
     /* set filtering query (or NULL) */
-    it->filterQuery = dd->filterQuery;
+    if(!!(it->filterQuery = dd->filterQuery)) {
+        const struct hdql_AttrDef * ad = hdql_query_top_attr(it->filterQuery);
+        assert(ad);
+        hdql_ValueTypeCode_t valueTCode = hdql_attr_def_get_atomic_value_type_code(ad);
+        it->filterVI = hdql_types_get_type( hdql_context_get_types(ctx)
+                , valueTCode);
+        /* allocate logic result */
+        struct hdql_ValueTypes * vts = hdql_context_get_types(ctx);
+        hdql_ValueTypeCode_t logicCode = hdql_types_get_type_code(vts, "hdql_Bool_t");
+        assert(0x0 != logicCode);
+        if(logicCode != valueTCode) {
+            /* get converter */
+            struct hdql_Converters * cnvs = hdql_context_get_conversions(ctx);
+            it->toLogicFilterResultConverter = hdql_converters_get(cnvs, logicCode, valueTCode);
+            if(NULL == it->toLogicFilterResultConverter) {
+                hdql_context_err_push( ctx, HDQL_ERR_CONVERSION
+                    , "Type <%s> can't be converted to boolean value (to be used"
+                      " in filter expression).", it->filterVI->name );
+                hdql_context_free(ctx, (hdql_Datum_t) it);
+                return NULL;
+            }
+        } else {
+            it->toLogicFilterResultConverter = NULL;
+        }
+    } else {
+        it->filterVI = NULL;
+    }
+
     /* populate bound queries refs for the attribute definition of
      * binding compound. Once query for binding compound gets reset
      * or advanced, the values get updated */
@@ -233,18 +264,36 @@ _hdql_cartesian_product_as_collection_dereference( hdql_It_t it_
     return it->owner;
 }
 
+
 static hdql_It_t
 _hdql_cartesian_product_as_collection_advance( hdql_It_t it_ ) {
     struct QueryProdIterator * it = (struct QueryProdIterator *) it_;
-    int rc = hdql_query_product_advance( it->boundQueries
-        , it->keys
-        , it->values
-        , it->owner
-        , it->nBindingQueries
-        , it->context
-        );
-    if(HDQL_ERR_CODE_OK != rc)
-        it->owner = NULL;
+    do {
+        int rc = hdql_query_product_advance( it->boundQueries
+            , it->keys
+            , it->values
+            , it->owner
+            , it->nBindingQueries
+            , it->context
+            );
+        if(HDQL_ERR_EMPTY_SET == rc) {
+            it->owner = NULL;
+            break;
+        }
+        if(it->filterQuery) {
+            hdql_query_reset(it->filterQuery, it->owner, it->context);
+            hdql_Datum_t r = hdql_query_get(it->filterQuery, NULL, it->context);
+            if(NULL == r) continue;
+            assert(r);
+            if(it->toLogicFilterResultConverter) {
+                int rc = it->toLogicFilterResultConverter(((hdql_Datum_t) &(it->filterLogicResult)), r);
+                assert(0 == rc); /*todo: handle rc != 0*/
+            } else {
+                it->filterLogicResult = *((hdql_Bool_t *) r);
+            }
+            if(it->filterLogicResult) break;
+        }
+    } while(it->filterQuery);
     return it_;
 }
 
@@ -267,7 +316,35 @@ _hdql_cartesian_product_as_collection_reset( hdql_It_t it_
         , it->nBindingQueries
         , it->context = ctx
         );
-    assert(0 == rc);  /* TODO we have no means to forward errors here */
+    if(rc == HDQL_ERR_EMPTY_SET) {
+        it->owner = NULL;
+        return it_;
+    }
+    while(it->filterQuery && rc != HDQL_ERR_EMPTY_SET) {
+        hdql_query_reset(it->filterQuery, it->owner, it->context);
+        hdql_Datum_t r = hdql_query_get(it->filterQuery, NULL, it->context);
+        if(NULL == r) continue;
+        assert(r);
+        if(it->toLogicFilterResultConverter) {
+            int rc = it->toLogicFilterResultConverter(((hdql_Datum_t) &(it->filterLogicResult)), r);
+            assert(0 == rc); /*todo: handle rc != 0*/
+        } else {
+            it->filterLogicResult = *((hdql_Bool_t *) r);
+        }
+        if(it->filterLogicResult) break;
+
+        rc = hdql_query_product_advance( it->boundQueries
+            , it->keys
+            , it->values
+            , it->owner
+            , it->nBindingQueries
+            , it->context
+            );
+        if(HDQL_ERR_EMPTY_SET == rc) {
+            it->owner = NULL;
+            break;
+        }
+    };
     return it_;
 }
 
@@ -275,7 +352,19 @@ static void
 _hdql_cartesian_product_destroy( hdql_It_t it_
                             , hdql_Context_t ctx
                             ) {
-    // ...
+    struct QueryProdIterator * it = hdql_cast(ctx, struct QueryProdIterator, it_);
+    for(size_t nq = 0; nq < it->nBindingQueries; ++nq) {
+        if(it->keys) {
+            hdql_query_keys_destroy(it->keys[nq], ctx);
+        }
+        hdql_query_destroy(it->boundQueries[nq], ctx);
+    }
+    if(it->keys) {
+        hdql_context_free(ctx, (hdql_Datum_t) it->keys);
+    }
+    hdql_context_free(ctx, (hdql_Datum_t) it->values);
+    hdql_context_free(ctx, (hdql_Datum_t) it->boundQueries);
+    hdql_context_free(ctx, (hdql_Datum_t) it_);
 }
 
 

--- a/src/ifaces/bound-value.c
+++ b/src/ifaces/bound-value.c
@@ -9,6 +9,7 @@
 
 #include <alloca.h>
 #include <assert.h>
+#include <strings.h>
 
 /* Bound value implements forwarded access interface over the object managed
  * externally. Perculiar feature is that these iface has two stages in its
@@ -41,8 +42,7 @@ struct BoundValueDefinitionData {
 
 hdql_Datum_t
 hdql_bound_value_interface_definition_data_init(struct hdql_Query * q, hdql_Context_t ctx) {
-    struct BoundValueDefinitionData * d = (struct BoundValueDefinitionData *)
-            hdql_context_alloc(ctx, sizeof(struct BoundValueDefinitionData));
+    struct BoundValueDefinitionData * d = hdql_alloc(ctx, struct BoundValueDefinitionData);
     d->q = q;
     d->value = NULL;
     return (hdql_Datum_t) d;
@@ -118,12 +118,58 @@ struct QueryProdIterator {
 
     struct hdql_Query ** boundQueries;
     hdql_Datum_t * values;
+    /* de-structured list of keys, a cache */
     struct hdql_CollectionKey ** keys;
 
     hdql_Datum_t owner;
     size_t nBindingQueries;
     hdql_Context_t context;
 };
+
+/* callback to count bound attributes, expect ud to be dest counter of size_t */
+static int
+_count_bound_attributes(const char *attrName
+        , size_t nAttr
+        , const struct hdql_AttrDef * ad
+        , void * ud
+) {
+    size_t * count = (size_t *) ud;
+    if(hdql_attr_def_is_bound(ad)) ++(*count);
+    return 0;
+}
+
+/* userdata type for _bind_query() callback */
+typedef struct {
+    size_t nBoundAttr;
+    struct QueryProdIterator * it;
+} _BindQueryUD_t;
+
+static int
+_bind_query(const char *attrName, size_t nAttr, const struct hdql_AttrDef *attrAD, void * ud_) {
+    _BindQueryUD_t * ud = (_BindQueryUD_t*) ud_;
+    if(!hdql_attr_def_is_bound(attrAD)) return 0;  /* continue */
+    const struct hdql_ScalarAttrInterface * boundAttrIFace
+            = hdql_attr_def_scalar_iface(attrAD);
+    assert(boundAttrIFace->dereference == _hdql_gBoundQueryIFace.dereference);
+    /* ^^^ otherwise, how come it became a "bound attribute"? */
+    assert(boundAttrIFace->definitionData);
+    /* ^^^ otherwise, how this iface was instantiated?
+     * hdql_bound_value_interface_definition_data_init() must be used */
+    struct BoundValueDefinitionData * bDefData
+        = (struct BoundValueDefinitionData*) boundAttrIFace->definitionData;
+    ud->it->boundQueries[ud->nBoundAttr] = bDefData->q;
+    #ifndef NDEBUG
+    int rc =
+    #endif
+        hdql_query_keys_reserve( bDefData->q
+                               , ud->it->keys + ud->nBoundAttr
+                               , ud->it->context
+                               );
+    assert(0 == rc);
+    bDefData->value = ud->it->values + ud->nBoundAttr;
+    ++(ud->nBoundAttr);
+    return 0;
+}
 
 static hdql_It_t
 _hdql_cartesian_product_as_collection_create( hdql_Datum_t owner
@@ -135,57 +181,29 @@ _hdql_cartesian_product_as_collection_create( hdql_Datum_t owner
             = hdql_cast(ctx, struct hdql_BindingCompoundCollectionDefData, defData_);
     /* allocate definition data for transient interface */
     struct QueryProdIterator * it = hdql_alloc(ctx, struct QueryProdIterator);
-
-    /*
-     * Init value interface and filtering
-     */
-
-
-
-    /*
-     * init Cartesian product
-     */
-
+    it->context = ctx;
     /* set filtering query (or NULL) */
     it->filterQuery = dd->filterQuery;
     /* populate bound queries refs for the attribute definition of
      * binding compound. Once query for binding compound gets reset
      * or advanced, the values get updated */
     it->nBindingQueries = 0;
-    const size_t nAttrsOverall = hdql_compound_get_nattrs(dd->vCompound);
-    const char ** names = alloca(sizeof(char*)*nAttrsOverall);
-    hdql_compound_get_attr_names(dd->vCompound, names);
-    for(size_t nAttr = 0; nAttr < nAttrsOverall; ++nAttr) {
-        const struct hdql_AttrDef * attrAD = hdql_compound_get_attr(dd->vCompound, names[nAttr]);
-        if(hdql_attr_def_is_bound(attrAD)) ++(it->nBindingQueries);
-    }
+    hdql_compound_for_each_own_attribute(dd->vCompound
+            , _count_bound_attributes
+            , &(it->nBindingQueries));
     assert(it->nBindingQueries > 0);  /* otherwise this compound could not be "bound" */
-
     /* allocate arrays for queries, value ptrs, keys */
     it->boundQueries = (struct hdql_Query **)
             hdql_context_alloc(ctx
-                , it->nBindingQueries * sizeof(struct hdql_Query *));
+                , it->nBindingQueries*sizeof(struct hdql_Query *));
+    /* see comments to issue #14 -- we currently have to allocate and maintain
+     * keys unconditionally, but that must be changed in the future */
+    it->keys = (struct hdql_CollectionKey **)
+            hdql_context_alloc(ctx
+                , it->nBindingQueries*sizeof(struct hdql_CollectionKey *));
     it->values = (hdql_Datum_t *) hdql_context_alloc(ctx, sizeof(hdql_Datum_t *)*it->nBindingQueries);
-
-    size_t nBoundAttr = 0;
-    for(size_t nAttr = 0; nAttr < nAttrsOverall; ++nAttr) {
-        const struct hdql_AttrDef * attrAD = hdql_compound_get_attr(dd->vCompound, names[nAttr]);
-        if(!hdql_attr_def_is_bound(attrAD)) continue;
-        const struct hdql_ScalarAttrInterface * boundAttrIFace
-                = hdql_attr_def_scalar_iface(attrAD);
-        assert(boundAttrIFace->dereference == _hdql_gBoundQueryIFace.dereference);
-        /* ^^^ otherwise, how come it became a "bound attribute"? */
-        assert(boundAttrIFace->definitionData);
-        /* ^^^ otherwise, how this iface was instantiated?
-         * hdql_bound_value_interface_definition_data_init() must be used */
-        struct BoundValueDefinitionData * bDefData
-            = (struct BoundValueDefinitionData*) boundAttrIFace->definitionData;
-        it->boundQueries[nBoundAttr] = bDefData->q;
-        bDefData->value = it->values + nBoundAttr;
-        ++nBoundAttr;
-    }
-    printf( "XXX Cartesian product initialized to handle %zu bound attributes\n"
-          , it->nBindingQueries );
+    _BindQueryUD_t bqud = {.it = it, .nBoundAttr = 0};
+    hdql_compound_for_each_own_attribute(dd->vCompound, _bind_query, &bqud);
     /* assign definition data to this transient interface */
     return (hdql_It_t) it;
 }
@@ -195,6 +213,23 @@ _hdql_cartesian_product_as_collection_dereference( hdql_It_t it_
                                 , struct hdql_CollectionKey * keyPtr
                                 ) {
     struct QueryProdIterator * it = (struct QueryProdIterator *) it_;
+    if(keyPtr) {
+        //printf("XXX received key ptr %p, 1st is %p \n"
+        //        , keyPtr->pl.keysList, keyPtr->pl.keysList[0].pl.keysList);  // XXX
+        // ^^^ we receive here key wrapping the keys list we returned
+        //     during a reserve, not the reserved instance (reserved are
+        //     under the keyPtr->pl.keysList -- what a mess... see #14)
+        assert(keyPtr->isList);
+        assert(keyPtr->pl.keysList[it->nBindingQueries-1].isTerminal);
+        for(size_t nq = 0; nq < it->nBindingQueries; ++nq) {
+            //assert(keyPtr->pl.keysList[nq].isList);
+            if(!it->keys[nq]) continue;
+            hdql_query_keys_copy( keyPtr->pl.keysList[nq].pl.keysList
+                                , it->keys[nq]
+                                , it->context
+                                );
+        }
+    }
     return it->owner;
 }
 
@@ -243,6 +278,61 @@ _hdql_cartesian_product_destroy( hdql_It_t it_
     // ...
 }
 
+
+/* userdata type for _reserve_keys_list_for_binding_query() callback */
+typedef struct {
+    size_t nBoundAttr;
+    struct hdql_CollectionKey * keysLists;
+    hdql_Context_t ctx;
+} _AllocKeysUD_t;
+
+static int
+_reserve_keys_list_for_binding_query(const char * attrName, size_t nAttr
+        , const struct hdql_AttrDef * ad, void * ud_) {
+    if(!hdql_attr_def_is_bound(ad)) return 0;  /* continue */
+    _AllocKeysUD_t * ud = (_AllocKeysUD_t *) ud_;
+
+    const struct hdql_ScalarAttrInterface * boundAttrIFace
+            = hdql_attr_def_scalar_iface(ad);
+
+    assert(boundAttrIFace->dereference == _hdql_gBoundQueryIFace.dereference);
+    /* ^^^ otherwise, how come it became a "bound attribute"? */
+    assert(boundAttrIFace->definitionData);
+    /* ^^^ otherwise, how this iface was instantiated?
+     * hdql_bound_value_interface_definition_data_init() must be used */
+    struct BoundValueDefinitionData * bDefData
+        = (struct BoundValueDefinitionData*) boundAttrIFace->definitionData;
+    hdql_query_keys_reserve(bDefData->q, &(ud->keysLists[ud->nBoundAttr].pl.keysList), ud->ctx);
+    assert(ud->keysLists[ud->nBoundAttr].pl.keysList);
+    ud->keysLists[ud->nBoundAttr].isList = 0x1;
+    ud->keysLists[ud->nBoundAttr].code = 0x0;
+    ++(ud->nBoundAttr);
+    return 0;
+}
+
+struct hdql_CollectionKey * hdql_bound_compound_key_reserve(
+            const hdql_Datum_t defData_, hdql_Context_t ctx) {
+    struct hdql_BindingCompoundCollectionDefData * dd
+            = hdql_cast(ctx, struct hdql_BindingCompoundCollectionDefData, defData_);
+    assert(dd->vCompound);
+    size_t nBindingQueries = 0;
+    hdql_compound_for_each_own_attribute(dd->vCompound
+            , _count_bound_attributes
+            , &nBindingQueries);
+    assert(nBindingQueries > 0);  /* otherwise this compound could not be "bound" */
+    _AllocKeysUD_t ud = {.nBoundAttr = 0, .ctx = ctx};
+    /* top-level key (always a body of the list), see implementation
+     * of `hdql_attr_def_reserve_keys()` in attr-def.c and issue #14 */
+    ud.keysLists = (struct hdql_CollectionKey *) hdql_context_alloc(ctx
+            , nBindingQueries*sizeof(struct hdql_CollectionKey));
+    bzero(ud.keysLists, nBindingQueries*sizeof(struct hdql_CollectionKey));
+    hdql_compound_for_each_own_attribute(dd->vCompound
+            , _reserve_keys_list_for_binding_query
+            , &ud );
+    /* todo: this is required as external code expects us to allocate a list */
+    ud.keysLists[nBindingQueries-1].isTerminal = 0x1;
+    return ud.keysLists;
+}
 
 const struct hdql_CollectionAttrInterface _hdql_gBindingCompoundCollectionIFace = {
     .definitionData = NULL,  /* set by caller to the instance of `hdql_BoundCompoundDefinitionData` struct */

--- a/src/ifaces/fwd-query-as-scalar.c
+++ b/src/ifaces/fwd-query-as-scalar.c
@@ -85,7 +85,7 @@ _fwd_query_scalar_interface_destroy(
         , hdql_Context_t ctx
         ) {
     struct FwdQueryScalarState * dd = (struct FwdQueryScalarState *) dd_;
-    if(dd->keys) {
+    if(dd && dd->keys) {
         hdql_query_keys_destroy(dd->keys, ctx);
     }
     // NOTE: sub-queries get destroyed within virtual compound dtrs

--- a/src/query-key.c
+++ b/src/query-key.c
@@ -171,7 +171,7 @@ _hdql_for_each_key( const struct hdql_CollectionKey * keys
         else {
             assert(cKey->code == 0x0);
             assert(!cKey->isList);
-            assert(NULL == cKey->pl.keysList);
+            assert(NULL == cKey->pl.keysList);  /* list ptr is set, but is not a list and has 0 code */
         }
         #endif
         if(cKey->isTerminal) break;

--- a/src/query.cc
+++ b/src/query.cc
@@ -312,8 +312,9 @@ QueryState::reset( hdql_Datum_t newOwner
                         , ctx
                         );
                 if(NULL == state.scalar.dynamicSuppData) {
-                    throw std::runtime_error("Failed to instantiate"
-                            " access state object for scalar attribute");
+                    throw std::runtime_error("failed to instantiate"
+                            " access state object for scalar attribute"
+                            " (interface's instantiate() returned NULL)");
                 }
             }
             assert(iface->reset);  // provided `instantiate()`, but no `reset()`?
@@ -366,7 +367,7 @@ hdql_query_reset( struct hdql_Query * query
         query->reset(owner, ctx);
     } catch(std::runtime_error & e) {
         hdql_context_err_push(ctx, HDQL_ERR_BAD_QUERY_STATE
-                , "Can't re-set the query: %s", e.what());
+                , "can't re-set the query: %s", e.what());
         return HDQL_ERR_BAD_QUERY_STATE;
     }
     return HDQL_ERR_CODE_OK;
@@ -459,10 +460,11 @@ hdql_query_dump( FILE * outf
                ) {
     int rc;
     char buf[1024];
-    for(; q; q = static_cast<hdql_Query *>(q->next)) {
+    int nQ = 1;
+    for(; q; q = static_cast<hdql_Query *>(q->next), ++nQ) {
         rc = hdql_top_attr_str(q->subject, buf, sizeof(buf), context);
         if(0 != rc) return;
-        fputs(" * ", outf);
+        fprintf(outf, " %d) ", nQ);
         fputs(buf, outf);
         fputc('\n', outf);
     }

--- a/src/value.cc
+++ b/src/value.cc
@@ -141,7 +141,13 @@ public:
         }
         // otherwise, do parent lookup
         if(tierNo > _tier) {
-            throw std::runtime_error("Logic error: type of descendant context requested.");
+            char errbf[256];
+            snprintf(errbf, sizeof(errbf), "context integrity failure or"
+                    " malformed type ID: type id=%d of"
+                    " (apparently) descendant context requested from parent"
+                    " (type defined in tier %d, this tier is %d)"
+                    , code, (int) tierNo, (int) _tier);
+            throw std::runtime_error(errbf);
         }
         assert(_parent);
         return _parent->get_by_code(code);

--- a/test/iteration-tests.cc
+++ b/test/iteration-tests.cc
@@ -607,22 +607,23 @@ TEST_F(TestingEventStruct, iterationWorksOnDifferentLevelsOfRootObject) {
     hdql_KeyView keysView;
     hdql_keys_flat_view_update(q, keys, &keysView, _compounds.context_ptr());
     
-    hdql::test::Event ev;
     typedef void (*FillSampleCallback_t)(hdql::test::Event &);
     FillSampleCallback_t fs[] = { &hdql::test::fill_data_sample_1
-                , &hdql::test::fill_data_sample_2
-                , &hdql::test::fill_data_sample_3};
-    for(int i = 0; i < 3; ++i) {
-        fs[i](ev);
+                                , &hdql::test::fill_data_sample_2
+                                , &hdql::test::fill_data_sample_3
+                                };
+    for(int nExample = 0; nExample < 3; ++nExample) {
+        hdql::test::Event ev;
+        fs[nExample](ev);
         int rc = hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
         ASSERT_EQ(HDQL_ERR_CODE_OK, rc);
         while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
             // locate and mark as visited, assuring it was not visited before
             bool found = false;
             ASSERT_TRUE(keysView.interface->get_as_int);
+            auto keyAsInt = keysView.interface->get_as_int(keysView.keyPtr->pl.datum);
             for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
-                if( keysView.interface->get_as_int(keysView.keyPtr->pl.datum) != expectedQueryResults[i].key
-                 ) continue;
+                if(keyAsInt != expectedQueryResults[i].key) continue;
                 found = true;
                 EXPECT_FALSE(expectedQueryResults[i].visited)
                     << "Item is visited again: id=" << expectedQueryResults[i].key;

--- a/test/iteration-tests/arithmetics.cc
+++ b/test/iteration-tests/arithmetics.cc
@@ -1,0 +1,99 @@
+#include "../events-struct.hh"
+#include "../samples.hh"
+
+#include <gtest/gtest.h>
+
+using hdql::test::TestingEventStruct;
+
+//
+// Iteration with basic filtering works for virtual compound arithmetics
+
+TEST_F(TestingEventStruct, iterationWorksOnDifferentLevelsOfRootObject) {
+    const char expression[] = ".hits.rawData.time + .eventID";
+    static struct {
+        int key;
+        float result;
+        bool visited;
+    } expectedQueryResults[] = {
+        {101, .01 + 104501 },
+        {102, .02 + 104501 },
+        {103, .03 + 104501 },
+        {301, .05 + 104501 },
+
+        {401, .10 + 104502 },
+        {402, .11 + 104502 },
+        {501, .12 + 104502 },
+        {502, .15 + 104502 },
+
+        {10, .21 + 104503 },
+        {11, .23 + 104503 },
+        {12, .24 + 104503 },
+        {99, .25 + 104503 },
+    };
+
+    char errBuf[128]; int errDetails[5];
+    hdql_Query * q = hdql_compile_query( expression
+                              , _eventCompound
+                              , _compounds.context_ptr()
+                              , errBuf, sizeof(errBuf)
+                              , errDetails
+                              );
+    ASSERT_EQ(errDetails[0], 0);
+    // iterate over query results, check all expected keys and values appeared
+    //size_t nResult = 0;  // xxx
+    hdql_Datum_t r;
+    
+    hdql_CollectionKey * keys;
+    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
+
+    const hdql_AttrDef * ad = hdql_query_top_attr(q);
+    ASSERT_TRUE( ad );
+    //ASSERT_TRUE( topAttrDef->isCollection );
+    ASSERT_TRUE( hdql_attr_def_is_atomic(ad) );
+    ASSERT_NE( hdql_attr_def_get_atomic_value_type_code(ad), 0x0 );
+    const hdql_ValueInterface * vi
+        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
+    ASSERT_TRUE(vi);
+    size_t flatKeyViewLen = hdql_keys_flat_view_size(keys, _compounds.context_ptr());
+    ASSERT_EQ(1, flatKeyViewLen);
+    hdql_KeyView keysView;
+    hdql_keys_flat_view_update(q, keys, &keysView, _compounds.context_ptr());
+    
+    typedef void (*FillSampleCallback_t)(hdql::test::Event &);
+    FillSampleCallback_t fs[] = { &hdql::test::fill_data_sample_1
+                                , &hdql::test::fill_data_sample_2
+                                , &hdql::test::fill_data_sample_3
+                                };
+    for(int nExample = 0; nExample < 3; ++nExample) {
+        hdql::test::Event ev;
+        fs[nExample](ev);
+        int rc = hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
+        ASSERT_EQ(HDQL_ERR_CODE_OK, rc);
+        while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
+            // locate and mark as visited, assuring it was not visited before
+            bool found = false;
+            ASSERT_TRUE(keysView.interface->get_as_int);
+            auto keyAsInt = keysView.interface->get_as_int(keysView.keyPtr->pl.datum);
+            for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+                if(keyAsInt != expectedQueryResults[i].key) continue;
+                found = true;
+                EXPECT_FALSE(expectedQueryResults[i].visited)
+                    << "Item is visited again: id=" << expectedQueryResults[i].key;
+                expectedQueryResults[i].visited = true;
+                break;
+            }
+            EXPECT_TRUE(found);
+        }
+    }
+    
+    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
+
+    hdql_query_destroy(q, _compounds.context_ptr());
+
+    // assure all have been visited
+    for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+        EXPECT_TRUE(expectedQueryResults[i].visited)
+            << "Item was not visited: id=" << expectedQueryResults[i].key;
+    }
+};
+

--- a/test/iteration-tests/singular-query.cc
+++ b/test/iteration-tests/singular-query.cc
@@ -1,0 +1,231 @@
+#include "../events-struct.hh"
+#include "../samples.hh"
+
+#include <gtest/gtest.h>
+
+using hdql::test::TestingEventStruct;
+
+//
+// Retrieval of simple scalar atomic field within root compound instance
+
+TEST_F(TestingEventStruct, retrievesSimpleScalarValue) {
+    const char expression[] = ".eventID";
+
+    hdql::test::Event ev;
+    fill_data_sample_1(ev);
+    char errBuf[128]; int errDetails[5];
+    hdql_Query * q = hdql_compile_query( expression
+                              , _eventCompound
+                              , _compounds.context_ptr()
+                              , errBuf, sizeof(errBuf)
+                              , errDetails
+                              );
+    ASSERT_EQ(errDetails[0], 0);
+    // iterate over query results, check all expected keys and values appeared
+    hdql_Datum_t r;
+    size_t keysDepth = hdql_query_depth(q);
+    EXPECT_EQ(1, keysDepth);
+
+    hdql_CollectionKey * keys;
+    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
+
+    const hdql_AttrDef * ad = hdql_query_top_attr(q);
+    ASSERT_TRUE(ad);
+    ASSERT_FALSE(hdql_attr_def_is_collection(ad));
+    ASSERT_TRUE(hdql_attr_def_is_atomic(ad));
+    ASSERT_FALSE(hdql_attr_def_is_static_value(ad));
+    const hdql_ValueInterface * vi
+        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
+    ASSERT_TRUE(vi);
+    ASSERT_TRUE(vi->get_as_int);
+
+    size_t nVisited = 0;
+    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
+    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
+        EXPECT_EQ(0x0, keys[0].code);
+        EXPECT_EQ(ev.eventID, vi->get_as_int(r));
+        ++nVisited;
+    }
+    EXPECT_EQ(1, nVisited);
+
+    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
+
+    hdql_query_destroy(q, _compounds.context_ptr());
+}
+
+//
+// Iteration of two-level collection
+
+TEST_F(TestingEventStruct, straightDataIterationWorksOnSample1) {
+    // note, that since hits in track are in unordered_map, particular order is
+    // not guaranteed
+    const char expression[] = ".tracks.hits.x";
+    static struct {
+        int keys[3];
+        float result;
+        bool visited;
+    } expectedQueryResults[] = {
+        {{0, 101, -1}, 3.4},
+        {{0, 102, -1}, 4.5},
+        {{2, 103, -1}, 5.6},
+        {{2, 202, -1}, 6.7},
+        {{2, 301, -1}, 7.8},
+    };
+
+    hdql::test::Event ev;
+    fill_data_sample_1(ev);
+    char errBuf[128]; int errDetails[5];
+    hdql_Query * q = hdql_compile_query( expression
+                              , _eventCompound
+                              , _compounds.context_ptr()
+                              , errBuf, sizeof(errBuf)
+                              , errDetails
+                              );
+    ASSERT_EQ(errDetails[0], 0);
+    // iterate over query results, check all expected keys and values appeared
+    //size_t nResult = 0;  // xxx
+    hdql_Datum_t r;
+    size_t keysDepth = hdql_query_depth(q);
+    
+    hdql_CollectionKey * keys;
+    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
+
+    const hdql_AttrDef * ad = hdql_query_top_attr(q);
+    ASSERT_TRUE(ad);
+    ASSERT_FALSE(hdql_attr_def_is_collection(ad));
+    ASSERT_TRUE(hdql_attr_def_is_atomic(ad));
+    ASSERT_FALSE(hdql_attr_def_is_static_value(ad));
+    const hdql_ValueInterface * vi
+        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
+    ASSERT_TRUE(vi);
+    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
+    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
+        //printf("#%zu: ", nResult++);  // xxx
+        //char bf[32] = "";
+        int kk[3];  // key to control
+        for(size_t lvl = 0; lvl < keysDepth; ++lvl) {
+            if(0x0 == keys[lvl].code) {
+                kk[lvl] = -1;
+                //printf( " --- " );  // xxx
+                continue;
+            }
+            const hdql_ValueInterface * vi = hdql_types_get_type(_valueTypes, keys[lvl].code);
+            assert(vi->get_as_string);
+            //vi->get_as_string(keys[lvl].datum, bf, sizeof(bf));
+            //printf(" %s ", bf);
+            kk[lvl] = vi->get_as_int(keys[lvl].pl.datum);
+        }
+        //vi->get_as_string(r, bf, sizeof(bf));
+        //printf(" => %s\n", bf);
+        //printf("  type: %s\n", hdql_qeury_result_type(qr) ? ... );
+        // locate and mark as visited, assuring it was not visited before
+        bool found = false;
+        for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+            if( kk[0] != expectedQueryResults[i].keys[0]
+             || kk[1] != expectedQueryResults[i].keys[1]
+             || kk[2] != expectedQueryResults[i].keys[2]
+             ) continue;
+            found = true;
+            EXPECT_FALSE(expectedQueryResults[i].visited);
+            expectedQueryResults[i].visited = true;
+            break;
+        }
+        EXPECT_TRUE(found);
+    }
+    
+    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
+
+    hdql_query_destroy(q, _compounds.context_ptr());
+
+    // assure all have been visited
+    for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+        EXPECT_TRUE(expectedQueryResults[i].visited);
+    }
+};
+
+//
+// Selective iteration of two-level collection
+
+TEST_F(TestingEventStruct, selectiveDataIterationWorksOnSample1) {
+    // note, that since hits in track are in unordered_map, particular order is
+    // not guaranteed
+    const char expression[] = ".tracks[2:...].hits[202:...].x";
+    static struct {
+        int keys[3];
+        float result;
+        bool visited;
+    } expectedQueryResults[] = {
+        {{2, 202, -1}, 6.7},
+        {{2, 301, -1}, 7.8},
+    };
+
+    hdql::test::Event ev;
+    fill_data_sample_1(ev);
+    char errBuf[128]; int errDetails[5];
+    hdql_Query * q = hdql_compile_query( expression
+                              , _eventCompound
+                              , _compounds.context_ptr()
+                              , errBuf, sizeof(errBuf)
+                              , errDetails
+                              );
+    ASSERT_EQ(errDetails[0], 0) << "Can't compile query: " << errBuf;
+    // iterate over query results, check all expected keys and values appeared
+    //size_t nResult = 0;  // xxx
+    hdql_Datum_t r;
+    size_t keysDepth = hdql_query_depth(q);
+    
+    hdql_CollectionKey * keys;
+    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
+
+    const hdql_AttrDef * ad = hdql_query_top_attr(q);
+    ASSERT_TRUE( ad );
+    ASSERT_FALSE( hdql_attr_def_is_collection(ad) );
+    ASSERT_TRUE( hdql_attr_def_is_atomic(ad) );
+    ASSERT_FALSE( hdql_attr_def_is_static_value(ad) );
+    const hdql_ValueInterface * vi
+        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
+    ASSERT_TRUE(vi);
+    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
+    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
+        //printf("#%zu: ", nResult++);  // xxx
+        //char bf[32] = "";
+        int kk[3];  // key to control
+        for(size_t lvl = 0; lvl < keysDepth; ++lvl) {
+            if(0x0 == keys[lvl].code) {
+                kk[lvl] = -1;
+                //printf( " --- " );  // xxx
+                continue;
+            }
+            const hdql_ValueInterface * vi = hdql_types_get_type(_valueTypes, keys[lvl].code);
+            assert(vi->get_as_string);
+            //vi->get_as_string(keys[lvl].datum, bf, sizeof(bf));
+            //printf(" %s ", bf);
+            kk[lvl] = vi->get_as_int(keys[lvl].pl.datum);
+        }
+        //vi->get_as_string(r, bf, sizeof(bf));
+        //printf(" => %s\n", bf);
+        //printf("  type: %s\n", hdql_qeury_result_type(qr) ? ... );
+        // locate and mark as visited, assuring it was not visited before
+        bool found = false;
+        for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+            if( kk[0] != expectedQueryResults[i].keys[0]
+             || kk[1] != expectedQueryResults[i].keys[1]
+             || kk[2] != expectedQueryResults[i].keys[2]
+             ) continue;
+            found = true;
+            EXPECT_FALSE(expectedQueryResults[i].visited);
+            expectedQueryResults[i].visited = true;
+            break;
+        }
+        EXPECT_TRUE(found);
+    }
+    
+    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
+
+    hdql_query_destroy(q, _compounds.context_ptr());
+
+    // assure all have been visited
+    for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+        EXPECT_TRUE(expectedQueryResults[i].visited);
+    }
+};

--- a/test/iteration-tests/v-compound-bind.cc
+++ b/test/iteration-tests/v-compound-bind.cc
@@ -1,3 +1,4 @@
+#if 0
 #include "events-struct.hh"
 #include "hdql/attr-def.h"
 #include "hdql/compound.h"
@@ -9,243 +10,19 @@
 #include "hdql/types.h"
 #include "hdql/value.h"
 #include "samples.hh"
+#endif
+
+#include "../events-struct.hh"
+#include "../samples.hh"
 
 #include <gtest/gtest.h>
 
 using hdql::test::TestingEventStruct;
 
-//
-// Retrieval of simple scalar atomic field within root compound instance
-
-TEST_F(TestingEventStruct, retrievesSimpleScalarValue) {
-    const char expression[] = ".eventID";
-
-    hdql::test::Event ev;
-    fill_data_sample_1(ev);
-    char errBuf[128]; int errDetails[5];
-    hdql_Query * q = hdql_compile_query( expression
-                              , _eventCompound
-                              , _compounds.context_ptr()
-                              , errBuf, sizeof(errBuf)
-                              , errDetails
-                              );
-    ASSERT_EQ(errDetails[0], 0);
-    // iterate over query results, check all expected keys and values appeared
-    hdql_Datum_t r;
-    size_t keysDepth = hdql_query_depth(q);
-    EXPECT_EQ(1, keysDepth);
-
-    hdql_CollectionKey * keys;
-    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
-
-    const hdql_AttrDef * ad = hdql_query_top_attr(q);
-    ASSERT_TRUE(ad);
-    ASSERT_FALSE(hdql_attr_def_is_collection(ad));
-    ASSERT_TRUE(hdql_attr_def_is_atomic(ad));
-    ASSERT_FALSE(hdql_attr_def_is_static_value(ad));
-    const hdql_ValueInterface * vi
-        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
-    ASSERT_TRUE(vi);
-    ASSERT_TRUE(vi->get_as_int);
-
-    size_t nVisited = 0;
-    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
-    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
-        EXPECT_EQ(0x0, keys[0].code);
-        EXPECT_EQ(ev.eventID, vi->get_as_int(r));
-        ++nVisited;
-    }
-    EXPECT_EQ(1, nVisited);
-
-    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
-
-    hdql_query_destroy(q, _compounds.context_ptr());
-}
-
-//
-// Iteration of two-level collection
-
-TEST_F(TestingEventStruct, straightDataIterationWorksOnSample1) {
+TEST_F(TestingEventStruct, boundAttribute_DataIterationWorksOnSample1) {
     // note, that since hits in track are in unordered_map, particular order is
     // not guaranteed
-    const char expression[] = ".tracks.hits.x";
-    static struct {
-        int keys[3];
-        float result;
-        bool visited;
-    } expectedQueryResults[] = {
-        {{0, 101, -1}, 3.4},
-        {{0, 102, -1}, 4.5},
-        {{2, 103, -1}, 5.6},
-        {{2, 202, -1}, 6.7},
-        {{2, 301, -1}, 7.8},
-    };
-
-    hdql::test::Event ev;
-    fill_data_sample_1(ev);
-    char errBuf[128]; int errDetails[5];
-    hdql_Query * q = hdql_compile_query( expression
-                              , _eventCompound
-                              , _compounds.context_ptr()
-                              , errBuf, sizeof(errBuf)
-                              , errDetails
-                              );
-    ASSERT_EQ(errDetails[0], 0);
-    // iterate over query results, check all expected keys and values appeared
-    //size_t nResult = 0;  // xxx
-    hdql_Datum_t r;
-    size_t keysDepth = hdql_query_depth(q);
-    
-    hdql_CollectionKey * keys;
-    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
-
-    const hdql_AttrDef * ad = hdql_query_top_attr(q);
-    ASSERT_TRUE(ad);
-    ASSERT_FALSE(hdql_attr_def_is_collection(ad));
-    ASSERT_TRUE(hdql_attr_def_is_atomic(ad));
-    ASSERT_FALSE(hdql_attr_def_is_static_value(ad));
-    const hdql_ValueInterface * vi
-        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
-    ASSERT_TRUE(vi);
-    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
-    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
-        //printf("#%zu: ", nResult++);  // xxx
-        //char bf[32] = "";
-        int kk[3];  // key to control
-        for(size_t lvl = 0; lvl < keysDepth; ++lvl) {
-            if(0x0 == keys[lvl].code) {
-                kk[lvl] = -1;
-                //printf( " --- " );  // xxx
-                continue;
-            }
-            const hdql_ValueInterface * vi = hdql_types_get_type(_valueTypes, keys[lvl].code);
-            assert(vi->get_as_string);
-            //vi->get_as_string(keys[lvl].datum, bf, sizeof(bf));
-            //printf(" %s ", bf);
-            kk[lvl] = vi->get_as_int(keys[lvl].pl.datum);
-        }
-        //vi->get_as_string(r, bf, sizeof(bf));
-        //printf(" => %s\n", bf);
-        //printf("  type: %s\n", hdql_qeury_result_type(qr) ? ... );
-        // locate and mark as visited, assuring it was not visited before
-        bool found = false;
-        for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
-            if( kk[0] != expectedQueryResults[i].keys[0]
-             || kk[1] != expectedQueryResults[i].keys[1]
-             || kk[2] != expectedQueryResults[i].keys[2]
-             ) continue;
-            found = true;
-            EXPECT_FALSE(expectedQueryResults[i].visited);
-            expectedQueryResults[i].visited = true;
-            break;
-        }
-        EXPECT_TRUE(found);
-    }
-    
-    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
-
-    hdql_query_destroy(q, _compounds.context_ptr());
-
-    // assure all have been visited
-    for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
-        EXPECT_TRUE(expectedQueryResults[i].visited);
-    }
-};
-
-//
-// Selective iteration of two-level collection
-
-TEST_F(TestingEventStruct, selectiveDataIterationWorksOnSample1) {
-    // note, that since hits in track are in unordered_map, particular order is
-    // not guaranteed
-    const char expression[] = ".tracks[2:...].hits[202:...].x";
-    static struct {
-        int keys[3];
-        float result;
-        bool visited;
-    } expectedQueryResults[] = {
-        {{2, 202, -1}, 6.7},
-        {{2, 301, -1}, 7.8},
-    };
-
-    hdql::test::Event ev;
-    fill_data_sample_1(ev);
-    char errBuf[128]; int errDetails[5];
-    hdql_Query * q = hdql_compile_query( expression
-                              , _eventCompound
-                              , _compounds.context_ptr()
-                              , errBuf, sizeof(errBuf)
-                              , errDetails
-                              );
-    ASSERT_EQ(errDetails[0], 0) << "Can't compile query: " << errBuf;
-    // iterate over query results, check all expected keys and values appeared
-    //size_t nResult = 0;  // xxx
-    hdql_Datum_t r;
-    size_t keysDepth = hdql_query_depth(q);
-    
-    hdql_CollectionKey * keys;
-    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
-
-    const hdql_AttrDef * ad = hdql_query_top_attr(q);
-    ASSERT_TRUE( ad );
-    ASSERT_FALSE( hdql_attr_def_is_collection(ad) );
-    ASSERT_TRUE( hdql_attr_def_is_atomic(ad) );
-    ASSERT_FALSE( hdql_attr_def_is_static_value(ad) );
-    const hdql_ValueInterface * vi
-        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
-    ASSERT_TRUE(vi);
-    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
-    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
-        //printf("#%zu: ", nResult++);  // xxx
-        //char bf[32] = "";
-        int kk[3];  // key to control
-        for(size_t lvl = 0; lvl < keysDepth; ++lvl) {
-            if(0x0 == keys[lvl].code) {
-                kk[lvl] = -1;
-                //printf( " --- " );  // xxx
-                continue;
-            }
-            const hdql_ValueInterface * vi = hdql_types_get_type(_valueTypes, keys[lvl].code);
-            assert(vi->get_as_string);
-            //vi->get_as_string(keys[lvl].datum, bf, sizeof(bf));
-            //printf(" %s ", bf);
-            kk[lvl] = vi->get_as_int(keys[lvl].pl.datum);
-        }
-        //vi->get_as_string(r, bf, sizeof(bf));
-        //printf(" => %s\n", bf);
-        //printf("  type: %s\n", hdql_qeury_result_type(qr) ? ... );
-        // locate and mark as visited, assuring it was not visited before
-        bool found = false;
-        for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
-            if( kk[0] != expectedQueryResults[i].keys[0]
-             || kk[1] != expectedQueryResults[i].keys[1]
-             || kk[2] != expectedQueryResults[i].keys[2]
-             ) continue;
-            found = true;
-            EXPECT_FALSE(expectedQueryResults[i].visited);
-            expectedQueryResults[i].visited = true;
-            break;
-        }
-        EXPECT_TRUE(found);
-    }
-    
-    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
-
-    hdql_query_destroy(q, _compounds.context_ptr());
-
-    // assure all have been visited
-    for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
-        EXPECT_TRUE(expectedQueryResults[i].visited);
-    }
-};
-
-//
-// Iteration of virtual compound providing collection
-
-TEST_F(TestingEventStruct, virtualCompoundDataIterationWorksOnSample1) {
-    // note, that since hits in track are in unordered_map, particular order is
-    // not guaranteed
-    const char expression[] = ".tracks{h := .hits}.h.energyDeposition";
+    const char expression[] = ".tracks{h := *.hits}.h.energyDeposition";
     static struct {
         int keys[2];
         float result;
@@ -318,23 +95,46 @@ TEST_F(TestingEventStruct, virtualCompoundDataIterationWorksOnSample1) {
     }
 };
 
-//
-// Iteration works for two subsequent sub-queries
 
-TEST_F(TestingEventStruct, twoSubqueriesIterationWorksOnSample1) {
+
+TEST_F(TestingEventStruct, boundAttribute_DataIterationWorksAsCartesianProduct) {
     // note, that since hits in track are in unordered_map, particular order is
     // not guaranteed
-    const char expression[] = ".tracks{h := .hits{eDep := .energyDeposition}}.h.eDep";
+    const char expression[] = "{th:=*.tracks.hits, h:=*.hits}{dx:=.h.x-.th.x}.dx";
     static struct {
-        int keys[2];
+        int keys[3];
         float result;
         bool visited;
     } expectedQueryResults[] = {
-        {{0, 101}, 1.},
-        {{0, 102}, 2.},
-        {{2, 103}, 3.},
-        {{2, 202}, 4.},
-        {{2, 301}, 5.},
+        {{101, 0, 101}, 3.4 - 3.4},
+        {{102, 0, 101}, 4.5 - 3.4},
+        {{103, 0, 101}, 5.6 - 3.4},
+        {{202, 0, 101}, 6.7 - 3.4},
+        {{301, 0, 101}, 7.8 - 3.4},
+
+        {{101, 0, 102}, 3.4 - 4.5},
+        {{102, 0, 102}, 4.5 - 4.5},
+        {{103, 0, 102}, 5.6 - 4.5},
+        {{202, 0, 102}, 6.7 - 4.5},
+        {{301, 0, 102}, 7.8 - 4.5},
+
+        {{101, 2, 103}, 3.4 - 5.6},
+        {{102, 2, 103}, 4.5 - 5.6},
+        {{103, 2, 103}, 5.6 - 5.6},
+        {{202, 2, 103}, 6.7 - 5.6},
+        {{301, 2, 103}, 7.8 - 5.6},
+
+        {{101, 2, 202}, 3.4 - 6.7},
+        {{102, 2, 202}, 4.5 - 6.7},
+        {{103, 2, 202}, 5.6 - 6.7},
+        {{202, 2, 202}, 6.7 - 6.7},
+        {{301, 2, 202}, 7.8 - 6.7},
+
+        {{101, 2, 301}, 3.4 - 7.8},
+        {{102, 2, 301}, 4.5 - 7.8},
+        {{103, 2, 301}, 5.6 - 7.8},
+        {{202, 2, 301}, 6.7 - 7.8},
+        {{301, 2, 301}, 7.8 - 7.8},
     };
 
     hdql::test::Event ev;
@@ -351,120 +151,51 @@ TEST_F(TestingEventStruct, twoSubqueriesIterationWorksOnSample1) {
     //size_t nResult = 0;  // xxx
     hdql_Datum_t r;
     size_t keysDepth = hdql_query_depth(q);
-    ASSERT_EQ(keysDepth, 4);
-    
-    hdql_CollectionKey * keys;
-    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
-
-    const hdql_AttrDef * ad = hdql_query_top_attr(q);
-    ASSERT_TRUE(ad);
-    ASSERT_FALSE( hdql_attr_def_is_collection(ad) );
-    ASSERT_TRUE( hdql_attr_def_is_atomic(ad) );
-    ASSERT_NE( hdql_attr_def_get_atomic_value_type_code(ad), 0x0 );
-    const hdql_ValueInterface * vi
-        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
-    ASSERT_TRUE(vi);
-    size_t flatKeyViewLen = hdql_keys_flat_view_size(keys, _compounds.context_ptr());
-    ASSERT_EQ(2, flatKeyViewLen);
-    hdql_KeyView keysViews[2];
-    hdql_keys_flat_view_update(q, keys, keysViews, _compounds.context_ptr());
-    
-    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
-    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
-        // locate and mark as visited, assuring it was not visited before
-        bool found = false;
-        ASSERT_TRUE(keysViews[0].interface->get_as_int);
-        ASSERT_TRUE(keysViews[1].interface->get_as_int);
-        for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
-            if( keysViews[0].interface->get_as_int(keysViews[0].keyPtr->pl.datum) != expectedQueryResults[i].keys[0]
-             || keysViews[1].interface->get_as_int(keysViews[1].keyPtr->pl.datum) != expectedQueryResults[i].keys[1]
-             ) continue;
-            found = true;
-            EXPECT_FALSE(expectedQueryResults[i].visited);
-            expectedQueryResults[i].visited = true;
-            break;
-        }
-        EXPECT_TRUE(found);
-    }
-    
-    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
-
-    hdql_query_destroy(q, _compounds.context_ptr());
-
-    // assure all have been visited
-    for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
-        EXPECT_TRUE(expectedQueryResults[i].visited);
-    }
-};
-
-
-//
-// Iteration works for virtual compound arithmetics
-
-TEST_F(TestingEventStruct, virtualCompoundArithmeticsWorksOnSample1) {
-    // note, that since hits in track are in unordered_map, particular order is
-    // not guaranteed
-    const char expression[] = ".tracks.hits{xy := .x*.y, xyz := .xy*.z}.xyz / 2";
-    static struct {
-        int keys[2];
-        float result;
-        bool visited;
-    } expectedQueryResults[] = {
-        {{0, 101}, 3.4*5.6*7.8/2 },
-        {{0, 102}, 4.5*6.7*8.9/2 },
-        {{2, 103}, 5.6*7.8*9.0/2 },
-        {{2, 202}, 6.7*8.9*0.1/2 },
-        {{2, 301}, 7.8*9.0*1.2/2 },
-    };
-
-    hdql::test::Event ev;
-    fill_data_sample_1(ev);
-    char errBuf[128]; int errDetails[5];
-    hdql_Query * q = hdql_compile_query( expression
-                              , _eventCompound
-                              , _compounds.context_ptr()
-                              , errBuf, sizeof(errBuf)
-                              , errDetails
-                              );
-    ASSERT_EQ(errDetails[0], 0);
-    // iterate over query results, check all expected keys and values appeared
-    //size_t nResult = 0;  // xxx
-    hdql_Datum_t r;
-    size_t keysDepth = hdql_query_depth(q);
-    ASSERT_EQ(keysDepth, 1);
+    ASSERT_EQ(keysDepth, 3);
     
     hdql_CollectionKey * keys;
     ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
 
     const hdql_AttrDef * ad = hdql_query_top_attr(q);
     ASSERT_TRUE( ad );
-    ASSERT_TRUE( hdql_attr_def_is_collection(ad) );
+    ASSERT_FALSE( hdql_attr_def_is_collection(ad) );
     ASSERT_TRUE( hdql_attr_def_is_atomic(ad) );
     ASSERT_FALSE( hdql_attr_def_is_static_value(ad) );
     const hdql_ValueInterface * vi
         = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
     ASSERT_TRUE(vi);
+    ASSERT_TRUE(vi->get_as_float);
+
     size_t flatKeyViewLen = hdql_keys_flat_view_size(keys, _compounds.context_ptr());
-    ASSERT_EQ(2, flatKeyViewLen);
-    hdql_KeyView keysViews[2];
+    ASSERT_EQ(3, flatKeyViewLen);
+    hdql_KeyView keysViews[3];
     hdql_keys_flat_view_update(q, keys, keysViews, _compounds.context_ptr());
     
     hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
+    double v;
     while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
         // locate and mark as visited, assuring it was not visited before
         bool found = false;
         ASSERT_TRUE(keysViews[0].interface->get_as_int);
         ASSERT_TRUE(keysViews[1].interface->get_as_int);
+        ASSERT_TRUE(keysViews[2].interface->get_as_int);
+        v = vi->get_as_float(r);
         for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
             if( keysViews[0].interface->get_as_int(keysViews[0].keyPtr->pl.datum) != expectedQueryResults[i].keys[0]
              || keysViews[1].interface->get_as_int(keysViews[1].keyPtr->pl.datum) != expectedQueryResults[i].keys[1]
+             || keysViews[2].interface->get_as_int(keysViews[2].keyPtr->pl.datum) != expectedQueryResults[i].keys[2]
              ) continue;
             found = true;
             EXPECT_FALSE(expectedQueryResults[i].visited);
+            EXPECT_NEAR(expectedQueryResults[i].result, v, 1e-6);
             expectedQueryResults[i].visited = true;
             break;
         }
-        EXPECT_TRUE(found);
+        EXPECT_TRUE(found) << "extra value: key=("
+            << keysViews[0].interface->get_as_int << ", "
+            << keysViews[1].interface->get_as_int << ", "
+            << keysViews[2].interface->get_as_int << ") value="
+            << v;
     }
     
     EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
@@ -477,20 +208,22 @@ TEST_F(TestingEventStruct, virtualCompoundArithmeticsWorksOnSample1) {
     }
 };
 
-//
-// Iteration with basic filtering works for virtual compound arithmetics
-
-TEST_F(TestingEventStruct, filteringWorksOnSample1) {
+TEST_F(TestingEventStruct, boundAttribute_DataIterationWorksAsCartesianProductOfFiltered) {
     // note, that since hits in track are in unordered_map, particular order is
     // not guaranteed
-    const char expression[] = ".tracks{: .chi2/.ndf > 3.4}.hits{: (.energyDeposition < 3.5 || .energyDeposition > 4.5)}.x";
+    const char expression[] = "{th:=*.tracks.hits{:.x > 5.7}, h:=*.hits{:.x < 5.7}}{dx:=.h.x-.th.x}.dx";
     static struct {
-        int keys[2];
+        int keys[3];
         float result;
         bool visited;
     } expectedQueryResults[] = {
-        {{2, 103}, .3 },
-        {{2, 301}, .4 },
+        {{101, 2, 202}, 3.4 - 6.7},
+        {{102, 2, 202}, 4.5 - 6.7},
+        {{103, 2, 202}, 5.6 - 6.7},
+
+        {{101, 2, 301}, 3.4 - 7.8},
+        {{102, 2, 301}, 4.5 - 7.8},
+        {{103, 2, 301}, 5.6 - 7.8},
     };
 
     hdql::test::Event ev;
@@ -506,40 +239,52 @@ TEST_F(TestingEventStruct, filteringWorksOnSample1) {
     // iterate over query results, check all expected keys and values appeared
     //size_t nResult = 0;  // xxx
     hdql_Datum_t r;
+    size_t keysDepth = hdql_query_depth(q);
+    ASSERT_EQ(keysDepth, 3);
     
     hdql_CollectionKey * keys;
     ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
 
     const hdql_AttrDef * ad = hdql_query_top_attr(q);
     ASSERT_TRUE( ad );
-    //ASSERT_TRUE( topAttrDef->isCollection );
+    ASSERT_FALSE( hdql_attr_def_is_collection(ad) );
     ASSERT_TRUE( hdql_attr_def_is_atomic(ad) );
-    ASSERT_NE( hdql_attr_def_get_atomic_value_type_code(ad), 0x0 );
+    ASSERT_FALSE( hdql_attr_def_is_static_value(ad) );
     const hdql_ValueInterface * vi
         = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
     ASSERT_TRUE(vi);
+    ASSERT_TRUE(vi->get_as_float);
+
     size_t flatKeyViewLen = hdql_keys_flat_view_size(keys, _compounds.context_ptr());
-    ASSERT_EQ(2, flatKeyViewLen);
-    hdql_KeyView keysViews[2];
+    ASSERT_EQ(3, flatKeyViewLen);
+    hdql_KeyView keysViews[3];
     hdql_keys_flat_view_update(q, keys, keysViews, _compounds.context_ptr());
     
-    int rc = hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
-    ASSERT_EQ(HDQL_ERR_CODE_OK, rc);
+    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
+    double v;
     while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
         // locate and mark as visited, assuring it was not visited before
         bool found = false;
         ASSERT_TRUE(keysViews[0].interface->get_as_int);
         ASSERT_TRUE(keysViews[1].interface->get_as_int);
+        ASSERT_TRUE(keysViews[2].interface->get_as_int);
+        v = vi->get_as_float(r);
         for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
             if( keysViews[0].interface->get_as_int(keysViews[0].keyPtr->pl.datum) != expectedQueryResults[i].keys[0]
              || keysViews[1].interface->get_as_int(keysViews[1].keyPtr->pl.datum) != expectedQueryResults[i].keys[1]
+             || keysViews[2].interface->get_as_int(keysViews[2].keyPtr->pl.datum) != expectedQueryResults[i].keys[2]
              ) continue;
             found = true;
             EXPECT_FALSE(expectedQueryResults[i].visited);
+            EXPECT_NEAR(expectedQueryResults[i].result, v, 1e-6);
             expectedQueryResults[i].visited = true;
             break;
         }
-        EXPECT_TRUE(found);
+        EXPECT_TRUE(found) << "extra value: key=("
+            << keysViews[0].interface->get_as_int << ", "
+            << keysViews[1].interface->get_as_int << ", "
+            << keysViews[2].interface->get_as_int << ") value="
+            << v;
     }
     
     EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
@@ -552,33 +297,32 @@ TEST_F(TestingEventStruct, filteringWorksOnSample1) {
     }
 };
 
-
-//
-// Iteration with basic filtering works for virtual compound arithmetics
-
-TEST_F(TestingEventStruct, iterationWorksOnDifferentLevelsOfRootObject) {
-    const char expression[] = ".hits.rawData.time + .eventID";
+TEST_F(TestingEventStruct, boundAttribute_FilteredDataIterationWorksAsCartesianProduct_1) {
+    // note, that since hits in track are in unordered_map, particular order is
+    // not guaranteed
+    const char expression[] = "{th:=*.tracks.hits, h:=*.hits : .h.x > .th.x}{dx:=.h.x-.th.x}.dx";
     static struct {
-        int key;
+        int keys[3];
         float result;
         bool visited;
     } expectedQueryResults[] = {
-        {101, .01 + 104501 },
-        {102, .02 + 104501 },
-        {103, .03 + 104501 },
-        {301, .05 + 104501 },
+        {{102, 0, 101}, 4.5 - 3.4},
+        {{103, 0, 101}, 5.6 - 3.4},
+        {{202, 0, 101}, 6.7 - 3.4},
+        {{301, 0, 101}, 7.8 - 3.4},
 
-        {401, .10 + 104502 },
-        {402, .11 + 104502 },
-        {501, .12 + 104502 },
-        {502, .15 + 104502 },
+        {{103, 0, 102}, 5.6 - 4.5},
+        {{202, 0, 102}, 6.7 - 4.5},
+        {{301, 0, 102}, 7.8 - 4.5},
 
-        {10, .21 + 104503 },
-        {11, .23 + 104503 },
-        {12, .24 + 104503 },
-        {99, .25 + 104503 },
+        {{202, 2, 103}, 6.7 - 5.6},
+        {{301, 2, 103}, 7.8 - 5.6},
+
+        {{301, 2, 202}, 7.8 - 6.7},
     };
 
+    hdql::test::Event ev;
+    fill_data_sample_1(ev);
     char errBuf[128]; int errDetails[5];
     hdql_Query * q = hdql_compile_query( expression
                               , _eventCompound
@@ -590,48 +334,52 @@ TEST_F(TestingEventStruct, iterationWorksOnDifferentLevelsOfRootObject) {
     // iterate over query results, check all expected keys and values appeared
     //size_t nResult = 0;  // xxx
     hdql_Datum_t r;
+    size_t keysDepth = hdql_query_depth(q);
+    ASSERT_EQ(keysDepth, 3);
     
     hdql_CollectionKey * keys;
     ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
 
     const hdql_AttrDef * ad = hdql_query_top_attr(q);
     ASSERT_TRUE( ad );
-    //ASSERT_TRUE( topAttrDef->isCollection );
+    ASSERT_FALSE( hdql_attr_def_is_collection(ad) );
     ASSERT_TRUE( hdql_attr_def_is_atomic(ad) );
-    ASSERT_NE( hdql_attr_def_get_atomic_value_type_code(ad), 0x0 );
+    ASSERT_FALSE( hdql_attr_def_is_static_value(ad) );
     const hdql_ValueInterface * vi
         = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
     ASSERT_TRUE(vi);
+    ASSERT_TRUE(vi->get_as_float);
+
     size_t flatKeyViewLen = hdql_keys_flat_view_size(keys, _compounds.context_ptr());
-    ASSERT_EQ(1, flatKeyViewLen);
-    hdql_KeyView keysView;
-    hdql_keys_flat_view_update(q, keys, &keysView, _compounds.context_ptr());
+    ASSERT_EQ(3, flatKeyViewLen);
+    hdql_KeyView keysViews[3];
+    hdql_keys_flat_view_update(q, keys, keysViews, _compounds.context_ptr());
     
-    typedef void (*FillSampleCallback_t)(hdql::test::Event &);
-    FillSampleCallback_t fs[] = { &hdql::test::fill_data_sample_1
-                                , &hdql::test::fill_data_sample_2
-                                , &hdql::test::fill_data_sample_3
-                                };
-    for(int nExample = 0; nExample < 3; ++nExample) {
-        hdql::test::Event ev;
-        fs[nExample](ev);
-        int rc = hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
-        ASSERT_EQ(HDQL_ERR_CODE_OK, rc);
-        while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
-            // locate and mark as visited, assuring it was not visited before
-            bool found = false;
-            ASSERT_TRUE(keysView.interface->get_as_int);
-            auto keyAsInt = keysView.interface->get_as_int(keysView.keyPtr->pl.datum);
-            for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
-                if(keyAsInt != expectedQueryResults[i].key) continue;
-                found = true;
-                EXPECT_FALSE(expectedQueryResults[i].visited)
-                    << "Item is visited again: id=" << expectedQueryResults[i].key;
-                expectedQueryResults[i].visited = true;
-                break;
-            }
-            EXPECT_TRUE(found);
+    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
+    double v;
+    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
+        // locate and mark as visited, assuring it was not visited before
+        bool found = false;
+        ASSERT_TRUE(keysViews[0].interface->get_as_int);
+        ASSERT_TRUE(keysViews[1].interface->get_as_int);
+        ASSERT_TRUE(keysViews[2].interface->get_as_int);
+        v = vi->get_as_float(r);
+        for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+            if( keysViews[0].interface->get_as_int(keysViews[0].keyPtr->pl.datum) != expectedQueryResults[i].keys[0]
+             || keysViews[1].interface->get_as_int(keysViews[1].keyPtr->pl.datum) != expectedQueryResults[i].keys[1]
+             || keysViews[2].interface->get_as_int(keysViews[2].keyPtr->pl.datum) != expectedQueryResults[i].keys[2]
+             ) continue;
+            found = true;
+            EXPECT_FALSE(expectedQueryResults[i].visited);
+            EXPECT_NEAR(expectedQueryResults[i].result, v, 1e-6);
+            expectedQueryResults[i].visited = true;
+            break;
         }
+        EXPECT_TRUE(found) << "extra value: key=("
+            << keysViews[0].interface->get_as_int << ", "
+            << keysViews[1].interface->get_as_int << ", "
+            << keysViews[2].interface->get_as_int << ") value="
+            << v;
     }
     
     EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
@@ -640,8 +388,101 @@ TEST_F(TestingEventStruct, iterationWorksOnDifferentLevelsOfRootObject) {
 
     // assure all have been visited
     for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
-        EXPECT_TRUE(expectedQueryResults[i].visited)
-            << "Item was not visited: id=" << expectedQueryResults[i].key;
+        EXPECT_TRUE(expectedQueryResults[i].visited);
     }
 };
 
+TEST_F(TestingEventStruct, boundAttribute_FilteredDataIterationWorksAsCartesianProduct_2) {
+    // note, that since hits in track are in unordered_map, particular order is
+    // not guaranteed
+    const char expression[] = "{th:=*.tracks.hits, h:=*.hits : .th.x > .h.x}{dx:=.th.x-.h.x}.dx";
+    static struct {
+        int keys[3];
+        float result;
+        bool visited;
+    } expectedQueryResults[] = {
+        {{101, 0, 102},  4.5 - 3.4},
+
+        {{101, 2, 103},  5.6 - 3.4},
+        {{102, 2, 103},  5.6 - 4.5},
+
+        {{101, 2, 202},  6.7 - 3.4},
+        {{102, 2, 202},  6.7 - 4.5},
+        {{103, 2, 202},  6.7 - 5.6},
+
+        {{101, 2, 301},  7.8 - 3.4},
+        {{102, 2, 301},  7.8 - 4.5},
+        {{103, 2, 301},  7.8 - 5.6},
+        {{202, 2, 301},  7.8 - 6.7},
+    };
+
+    hdql::test::Event ev;
+    fill_data_sample_1(ev);
+    char errBuf[128]; int errDetails[5];
+    hdql_Query * q = hdql_compile_query( expression
+                              , _eventCompound
+                              , _compounds.context_ptr()
+                              , errBuf, sizeof(errBuf)
+                              , errDetails
+                              );
+    ASSERT_EQ(errDetails[0], 0);
+    // iterate over query results, check all expected keys and values appeared
+    //size_t nResult = 0;  // xxx
+    hdql_Datum_t r;
+    size_t keysDepth = hdql_query_depth(q);
+    ASSERT_EQ(keysDepth, 3);
+    
+    hdql_CollectionKey * keys;
+    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
+
+    const hdql_AttrDef * ad = hdql_query_top_attr(q);
+    ASSERT_TRUE( ad );
+    ASSERT_FALSE( hdql_attr_def_is_collection(ad) );
+    ASSERT_TRUE( hdql_attr_def_is_atomic(ad) );
+    ASSERT_FALSE( hdql_attr_def_is_static_value(ad) );
+    const hdql_ValueInterface * vi
+        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
+    ASSERT_TRUE(vi);
+    ASSERT_TRUE(vi->get_as_float);
+
+    size_t flatKeyViewLen = hdql_keys_flat_view_size(keys, _compounds.context_ptr());
+    ASSERT_EQ(3, flatKeyViewLen);
+    hdql_KeyView keysViews[3];
+    hdql_keys_flat_view_update(q, keys, keysViews, _compounds.context_ptr());
+    
+    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
+    double v;
+    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
+        // locate and mark as visited, assuring it was not visited before
+        bool found = false;
+        ASSERT_TRUE(keysViews[0].interface->get_as_int);
+        ASSERT_TRUE(keysViews[1].interface->get_as_int);
+        ASSERT_TRUE(keysViews[2].interface->get_as_int);
+        v = vi->get_as_float(r);
+        for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+            if( keysViews[0].interface->get_as_int(keysViews[0].keyPtr->pl.datum) != expectedQueryResults[i].keys[0]
+             || keysViews[1].interface->get_as_int(keysViews[1].keyPtr->pl.datum) != expectedQueryResults[i].keys[1]
+             || keysViews[2].interface->get_as_int(keysViews[2].keyPtr->pl.datum) != expectedQueryResults[i].keys[2]
+             ) continue;
+            found = true;
+            EXPECT_FALSE(expectedQueryResults[i].visited);
+            EXPECT_NEAR(expectedQueryResults[i].result, v, 1e-6);
+            expectedQueryResults[i].visited = true;
+            break;
+        }
+        EXPECT_TRUE(found) << "extra value: key=("
+            << keysViews[0].interface->get_as_int << ", "
+            << keysViews[1].interface->get_as_int << ", "
+            << keysViews[2].interface->get_as_int << ") value="
+            << v;
+    }
+    
+    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
+
+    hdql_query_destroy(q, _compounds.context_ptr());
+
+    // assure all have been visited
+    for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+        EXPECT_TRUE(expectedQueryResults[i].visited);
+    }
+};

--- a/test/iteration-tests/v-compound-fwd.cc
+++ b/test/iteration-tests/v-compound-fwd.cc
@@ -1,0 +1,320 @@
+#include "../events-struct.hh"
+#include "../samples.hh"
+
+#include <gtest/gtest.h>
+
+using hdql::test::TestingEventStruct;
+
+//
+// Iteration of virtual compound providing collection
+
+TEST_F(TestingEventStruct, forwardingAttribute_DataIterationWorksOnSample1) {
+    // note, that since hits in track are in unordered_map, particular order is
+    // not guaranteed
+    const char expression[] = ".tracks{h := .hits}.h.energyDeposition";
+    static struct {
+        int keys[2];
+        float result;
+        bool visited;
+    } expectedQueryResults[] = {
+        {{0, 101}, 1.},
+        {{0, 102}, 2.},
+        {{2, 103}, 3.},
+        {{2, 202}, 4.},
+        {{2, 301}, 5.},
+    };
+
+    hdql::test::Event ev;
+    fill_data_sample_1(ev);
+    char errBuf[128]; int errDetails[5];
+    hdql_Query * q = hdql_compile_query( expression
+                              , _eventCompound
+                              , _compounds.context_ptr()
+                              , errBuf, sizeof(errBuf)
+                              , errDetails
+                              );
+    ASSERT_EQ(errDetails[0], 0);
+    // iterate over query results, check all expected keys and values appeared
+    //size_t nResult = 0;  // xxx
+    hdql_Datum_t r;
+    size_t keysDepth = hdql_query_depth(q);
+    ASSERT_EQ(keysDepth, 4);
+    
+    hdql_CollectionKey * keys;
+    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
+
+    const hdql_AttrDef * ad = hdql_query_top_attr(q);
+    ASSERT_TRUE( ad );
+    ASSERT_FALSE( hdql_attr_def_is_collection(ad) );
+    ASSERT_TRUE( hdql_attr_def_is_atomic(ad) );
+    ASSERT_FALSE( hdql_attr_def_is_static_value(ad) );
+    const hdql_ValueInterface * vi
+        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
+    ASSERT_TRUE(vi);
+    size_t flatKeyViewLen = hdql_keys_flat_view_size(keys, _compounds.context_ptr());
+    ASSERT_EQ(2, flatKeyViewLen);
+    hdql_KeyView keysViews[2];
+    hdql_keys_flat_view_update(q, keys, keysViews, _compounds.context_ptr());
+    
+    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
+    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
+        // locate and mark as visited, assuring it was not visited before
+        bool found = false;
+        ASSERT_TRUE(keysViews[0].interface->get_as_int);
+        ASSERT_TRUE(keysViews[1].interface->get_as_int);
+        for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+            if( keysViews[0].interface->get_as_int(keysViews[0].keyPtr->pl.datum) != expectedQueryResults[i].keys[0]
+             || keysViews[1].interface->get_as_int(keysViews[1].keyPtr->pl.datum) != expectedQueryResults[i].keys[1]
+             ) continue;
+            found = true;
+            EXPECT_FALSE(expectedQueryResults[i].visited);
+            expectedQueryResults[i].visited = true;
+            break;
+        }
+        EXPECT_TRUE(found);
+    }
+    
+    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
+
+    hdql_query_destroy(q, _compounds.context_ptr());
+
+    // assure all have been visited
+    for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+        EXPECT_TRUE(expectedQueryResults[i].visited);
+    }
+};
+
+//
+// Iteration works for two subsequent sub-queries
+
+TEST_F(TestingEventStruct, twoSubqueriesIterationWorksOnSample1) {
+    // note, that since hits in track are in unordered_map, particular order is
+    // not guaranteed
+    const char expression[] = ".tracks{h := .hits{eDep := .energyDeposition}}.h.eDep";
+    static struct {
+        int keys[2];
+        float result;
+        bool visited;
+    } expectedQueryResults[] = {
+        {{0, 101}, 1.},
+        {{0, 102}, 2.},
+        {{2, 103}, 3.},
+        {{2, 202}, 4.},
+        {{2, 301}, 5.},
+    };
+
+    hdql::test::Event ev;
+    fill_data_sample_1(ev);
+    char errBuf[128]; int errDetails[5];
+    hdql_Query * q = hdql_compile_query( expression
+                              , _eventCompound
+                              , _compounds.context_ptr()
+                              , errBuf, sizeof(errBuf)
+                              , errDetails
+                              );
+    ASSERT_EQ(errDetails[0], 0);
+    // iterate over query results, check all expected keys and values appeared
+    //size_t nResult = 0;  // xxx
+    hdql_Datum_t r;
+    size_t keysDepth = hdql_query_depth(q);
+    ASSERT_EQ(keysDepth, 4);
+    
+    hdql_CollectionKey * keys;
+    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
+
+    const hdql_AttrDef * ad = hdql_query_top_attr(q);
+    ASSERT_TRUE(ad);
+    ASSERT_FALSE( hdql_attr_def_is_collection(ad) );
+    ASSERT_TRUE( hdql_attr_def_is_atomic(ad) );
+    ASSERT_NE( hdql_attr_def_get_atomic_value_type_code(ad), 0x0 );
+    const hdql_ValueInterface * vi
+        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
+    ASSERT_TRUE(vi);
+    size_t flatKeyViewLen = hdql_keys_flat_view_size(keys, _compounds.context_ptr());
+    ASSERT_EQ(2, flatKeyViewLen);
+    hdql_KeyView keysViews[2];
+    hdql_keys_flat_view_update(q, keys, keysViews, _compounds.context_ptr());
+    
+    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
+    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
+        // locate and mark as visited, assuring it was not visited before
+        bool found = false;
+        ASSERT_TRUE(keysViews[0].interface->get_as_int);
+        ASSERT_TRUE(keysViews[1].interface->get_as_int);
+        for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+            if( keysViews[0].interface->get_as_int(keysViews[0].keyPtr->pl.datum) != expectedQueryResults[i].keys[0]
+             || keysViews[1].interface->get_as_int(keysViews[1].keyPtr->pl.datum) != expectedQueryResults[i].keys[1]
+             ) continue;
+            found = true;
+            EXPECT_FALSE(expectedQueryResults[i].visited);
+            expectedQueryResults[i].visited = true;
+            break;
+        }
+        EXPECT_TRUE(found);
+    }
+    
+    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
+
+    hdql_query_destroy(q, _compounds.context_ptr());
+
+    // assure all have been visited
+    for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+        EXPECT_TRUE(expectedQueryResults[i].visited);
+    }
+};
+
+
+//
+// Iteration works for virtual compound arithmetics
+
+TEST_F(TestingEventStruct, virtualCompoundArithmeticsWorksOnSample1) {
+    // note, that since hits in track are in unordered_map, particular order is
+    // not guaranteed
+    const char expression[] = ".tracks.hits{xy := .x*.y, xyz := .xy*.z}.xyz / 2";
+    static struct {
+        int keys[2];
+        float result;
+        bool visited;
+    } expectedQueryResults[] = {
+        {{0, 101}, 3.4*5.6*7.8/2 },
+        {{0, 102}, 4.5*6.7*8.9/2 },
+        {{2, 103}, 5.6*7.8*9.0/2 },
+        {{2, 202}, 6.7*8.9*0.1/2 },
+        {{2, 301}, 7.8*9.0*1.2/2 },
+    };
+
+    hdql::test::Event ev;
+    fill_data_sample_1(ev);
+    char errBuf[128]; int errDetails[5];
+    hdql_Query * q = hdql_compile_query( expression
+                              , _eventCompound
+                              , _compounds.context_ptr()
+                              , errBuf, sizeof(errBuf)
+                              , errDetails
+                              );
+    ASSERT_EQ(errDetails[0], 0);
+    // iterate over query results, check all expected keys and values appeared
+    //size_t nResult = 0;  // xxx
+    hdql_Datum_t r;
+    size_t keysDepth = hdql_query_depth(q);
+    ASSERT_EQ(keysDepth, 1);
+    
+    hdql_CollectionKey * keys;
+    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
+
+    const hdql_AttrDef * ad = hdql_query_top_attr(q);
+    ASSERT_TRUE( ad );
+    ASSERT_TRUE( hdql_attr_def_is_collection(ad) );
+    ASSERT_TRUE( hdql_attr_def_is_atomic(ad) );
+    ASSERT_FALSE( hdql_attr_def_is_static_value(ad) );
+    const hdql_ValueInterface * vi
+        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
+    ASSERT_TRUE(vi);
+    size_t flatKeyViewLen = hdql_keys_flat_view_size(keys, _compounds.context_ptr());
+    ASSERT_EQ(2, flatKeyViewLen);
+    hdql_KeyView keysViews[2];
+    hdql_keys_flat_view_update(q, keys, keysViews, _compounds.context_ptr());
+    
+    hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
+    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
+        // locate and mark as visited, assuring it was not visited before
+        bool found = false;
+        ASSERT_TRUE(keysViews[0].interface->get_as_int);
+        ASSERT_TRUE(keysViews[1].interface->get_as_int);
+        for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+            if( keysViews[0].interface->get_as_int(keysViews[0].keyPtr->pl.datum) != expectedQueryResults[i].keys[0]
+             || keysViews[1].interface->get_as_int(keysViews[1].keyPtr->pl.datum) != expectedQueryResults[i].keys[1]
+             ) continue;
+            found = true;
+            EXPECT_FALSE(expectedQueryResults[i].visited);
+            expectedQueryResults[i].visited = true;
+            break;
+        }
+        EXPECT_TRUE(found);
+    }
+    
+    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
+
+    hdql_query_destroy(q, _compounds.context_ptr());
+
+    // assure all have been visited
+    for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+        EXPECT_TRUE(expectedQueryResults[i].visited);
+    }
+};
+
+//
+// Iteration with basic filtering works for virtual compound arithmetics
+
+TEST_F(TestingEventStruct, filteringWorksOnSample1) {
+    // note, that since hits in track are in unordered_map, particular order is
+    // not guaranteed
+    const char expression[] = ".tracks{: .chi2/.ndf > 3.4}.hits{: (.energyDeposition < 3.5 || .energyDeposition > 4.5)}.x";
+    static struct {
+        int keys[2];
+        float result;
+        bool visited;
+    } expectedQueryResults[] = {
+        {{2, 103}, .3 },
+        {{2, 301}, .4 },
+    };
+
+    hdql::test::Event ev;
+    fill_data_sample_1(ev);
+    char errBuf[128]; int errDetails[5];
+    hdql_Query * q = hdql_compile_query( expression
+                              , _eventCompound
+                              , _compounds.context_ptr()
+                              , errBuf, sizeof(errBuf)
+                              , errDetails
+                              );
+    ASSERT_EQ(errDetails[0], 0);
+    // iterate over query results, check all expected keys and values appeared
+    //size_t nResult = 0;  // xxx
+    hdql_Datum_t r;
+    
+    hdql_CollectionKey * keys;
+    ASSERT_EQ(0, hdql_query_keys_reserve(q, &keys, _compounds.context_ptr()));
+
+    const hdql_AttrDef * ad = hdql_query_top_attr(q);
+    ASSERT_TRUE( ad );
+    //ASSERT_TRUE( topAttrDef->isCollection );
+    ASSERT_TRUE( hdql_attr_def_is_atomic(ad) );
+    ASSERT_NE( hdql_attr_def_get_atomic_value_type_code(ad), 0x0 );
+    const hdql_ValueInterface * vi
+        = hdql_types_get_type(_valueTypes, hdql_attr_def_get_atomic_value_type_code(ad));
+    ASSERT_TRUE(vi);
+    size_t flatKeyViewLen = hdql_keys_flat_view_size(keys, _compounds.context_ptr());
+    ASSERT_EQ(2, flatKeyViewLen);
+    hdql_KeyView keysViews[2];
+    hdql_keys_flat_view_update(q, keys, keysViews, _compounds.context_ptr());
+    
+    int rc = hdql_query_reset(q, reinterpret_cast<hdql_Datum_t>(&ev), _compounds.context_ptr());
+    ASSERT_EQ(HDQL_ERR_CODE_OK, rc);
+    while(NULL != (r = hdql_query_get(q, keys, _compounds.context_ptr()))) {
+        // locate and mark as visited, assuring it was not visited before
+        bool found = false;
+        ASSERT_TRUE(keysViews[0].interface->get_as_int);
+        ASSERT_TRUE(keysViews[1].interface->get_as_int);
+        for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+            if( keysViews[0].interface->get_as_int(keysViews[0].keyPtr->pl.datum) != expectedQueryResults[i].keys[0]
+             || keysViews[1].interface->get_as_int(keysViews[1].keyPtr->pl.datum) != expectedQueryResults[i].keys[1]
+             ) continue;
+            found = true;
+            EXPECT_FALSE(expectedQueryResults[i].visited);
+            expectedQueryResults[i].visited = true;
+            break;
+        }
+        EXPECT_TRUE(found);
+    }
+    
+    EXPECT_EQ(0, hdql_query_keys_destroy(keys, _compounds.context_ptr()));
+
+    hdql_query_destroy(q, _compounds.context_ptr());
+
+    // assure all have been visited
+    for(size_t i = 0; i < sizeof(expectedQueryResults)/sizeof(*expectedQueryResults); ++i) {
+        EXPECT_TRUE(expectedQueryResults[i].visited);
+    }
+};
+

--- a/test/main.cc
+++ b/test/main.cc
@@ -87,7 +87,7 @@ test_query_on_data( int nSample, const char * expression ) {
         free(expCpy);
     }
     assert(q);
-    puts("-- query composition:");
+    puts("-- query composition (final result goes last):");
     hdql_query_dump(stdout, q, ctx);
     const hdql_AttrDef * topAttrDef = hdql_query_top_attr(q);
     // iterate over query results
@@ -145,7 +145,7 @@ test_query_on_data( int nSample, const char * expression ) {
         }
         #endif
 
-        puts("-- query results:");
+        printf("-- sample #%d query results:", i);
         while(NULL != (r = hdql_query_get(q, keys, ctx))) {
             hadResult = true;
             if(flatKeyViewLength) {

--- a/test/main.cc
+++ b/test/main.cc
@@ -20,6 +20,104 @@
 #include <cstdio>
 #include <cassert>
 
+// aux function to print 1st level of compound item
+static void print_compound_instance_1st_tier(hdql_Datum_t d, hdql_AttrDef_t ad) {
+    assert(hdql_attr_def_is_compound(ad));
+    const hdql_Compound * c = hdql_attr_def_compound_type_info(ad);
+    size_t n = hdql_compound_get_nattrs(c);
+    const char ** attrNames = (const char **) alloca(sizeof(char*)*n);
+    hdql_compound_get_attr_names(c, attrNames);
+    bool isFirst = true;
+    for(size_t nAttr = 0; nAttr < n; ++nAttr) {
+        if(isFirst) isFirst = false; else fputs(", ", stdout);
+        printf("`%s'", attrNames[nAttr]);
+    }
+}
+
+static void shallow_print_value(hdql_Datum_t r, hdql_AttrDef_t topAttrDef
+        , hdql_Context_t ctx) {
+    hdql_ValueTypes * valTypes = hdql_context_get_types(ctx);
+    if(hdql_attr_def_is_static_value(topAttrDef)) {  // returns static value
+        // xxx, example: `2 + 3'
+        printf( "static value %p of type %d"
+              ,  hdql_attr_def_get_static_value(topAttrDef)
+              , (int) hdql_attr_def_get_atomic_value_type_code(topAttrDef)
+              );
+        if(hdql_attr_def_get_atomic_value_type_code(topAttrDef)) {
+            const hdql_ValueInterface * vi
+                = hdql_types_get_type(valTypes, hdql_attr_def_get_atomic_value_type_code(topAttrDef));
+            if(vi && vi->get_as_string) {
+                char bf[32];
+                vi->get_as_string(r, bf, sizeof(bf), ctx);
+                printf( "value=\"%s\"", bf );
+            } else {
+                fputs(" (no value interface)", stdout);
+            }
+        }
+    } else if(hdql_attr_def_is_fwd_query(topAttrDef)) {  // forwarding query
+        printf("subquery %p", hdql_attr_def_fwd_query(topAttrDef));
+    } else if(!hdql_attr_def_is_atomic(topAttrDef)) {  // compound instance(s) of certain type
+        assert(hdql_attr_def_is_compound(topAttrDef));
+        const struct hdql_Compound * ct = hdql_attr_def_compound_type_info(topAttrDef);
+        if(!hdql_compound_is_virtual(ct)) {
+            printf( "compound %s instance %p of type `%s': "
+                  , hdql_attr_def_is_collection(topAttrDef) ? "collection" : "scalar"
+                  , r
+                  , hdql_compound_get_name(hdql_attr_def_compound_type_info(topAttrDef))
+                  );
+            print_compound_instance_1st_tier(r, topAttrDef);
+        } else {
+            char buf[128];
+            hdql_compound_get_full_type_str(ct, buf, sizeof(buf));
+            printf( "compound %s instance %p of type `%s': "
+                  , hdql_attr_def_is_collection(topAttrDef) ? "collection" : "scalar"
+                  , r
+                  , buf
+                  );
+            print_compound_instance_1st_tier(r, topAttrDef);
+        }
+    } else {  // atomic item
+        if(!hdql_attr_def_is_collection(topAttrDef)) {  // scalar compound attribute
+            // xxx, example: `.eventID', `.hits.x'
+            const hdql_ValueInterface * vi = hdql_types_get_type(valTypes
+                    , hdql_attr_def_get_atomic_value_type_code(topAttrDef) );
+            if(!vi) {
+                printf( "scalar instance %p of unknown type", r);
+            } else if(!vi->get_as_string) {
+                printf( "scalar instance %p of type <%s> (no to-string method)"
+                        , r, vi->name );
+            } else {
+                char valueBf[32];
+                vi->get_as_string(r, valueBf, sizeof(valueBf), ctx);
+                printf( "scalar instance %p of type <%s> with value \"%s\""
+                        , r, vi->name, valueBf );
+            }
+        } else {  // item from collection of atomic scalars (1d list or array)
+            // xxx, example: `.hits.rawData.samples'
+            #if 1
+            const hdql_ValueInterface * vi
+                = hdql_types_get_type(valTypes, hdql_attr_def_get_atomic_value_type_code(topAttrDef));
+            if(vi && vi->get_as_string) {
+                char bf[32];
+                vi->get_as_string(r, bf, sizeof(bf), ctx);
+                printf( "value=\"%s\"", bf );
+            } else {
+                fputs(" (no value interface)", stdout);
+            }
+            #else
+            // Query resulted in weird item
+            printf("??? (attr.def. provided, %s, %s, %s %s)"
+                  , topAttrDef->staticValueFlags ? "stat.val." : "not a static value"
+                  , topAttrDef->isSubQuery ? "subquery" : "not a subquery"
+                  , topAttrDef->isAtomic ? "atomic" : "compound"
+                  , topAttrDef->isCollection ? "collection" : "scalar"
+                  );
+            #endif
+        }
+    }
+    puts(".");
+}
+
 //
 // Example of event structs
 
@@ -145,7 +243,7 @@ test_query_on_data( int nSample, const char * expression ) {
         }
         #endif
 
-        printf("-- sample #%d query results:", i);
+        printf("-- sample #%d query results:\n", i);
         while(NULL != (r = hdql_query_get(q, keys, ctx))) {
             hadResult = true;
             if(flatKeyViewLength) {
@@ -175,83 +273,7 @@ test_query_on_data( int nSample, const char * expression ) {
                 fputs("??? (query did not provide attribute definition)", stdout);
             } else {  // valid result
                 fputs(flKStr, stdout);  // flat keys
-                if(hdql_attr_def_is_static_value(topAttrDef)) {  // returns static value
-                    // xxx, example: `2 + 3'
-                    printf( "static value %p of type %d"
-                          ,  hdql_attr_def_get_static_value(topAttrDef)
-                          , (int) hdql_attr_def_get_atomic_value_type_code(topAttrDef)
-                          );
-                    if(hdql_attr_def_get_atomic_value_type_code(topAttrDef)) {
-                        const hdql_ValueInterface * vi
-                            = hdql_types_get_type(valTypes, hdql_attr_def_get_atomic_value_type_code(topAttrDef));
-                        if(vi && vi->get_as_string) {
-                            char bf[32];
-                            vi->get_as_string(r, bf, sizeof(bf), ctx);
-                            printf( "value=\"%s\"", bf );
-                        } else {
-                            fputs(" (no value interface)", stdout);
-                        }
-                    }
-                } else if(hdql_attr_def_is_fwd_query(topAttrDef)) {  // forwarding query
-                    printf("subquery %p", hdql_attr_def_fwd_query(topAttrDef));
-                } else if(!hdql_attr_def_is_atomic(topAttrDef)) {  // compound instance(s) of certain type
-                    assert(hdql_attr_def_is_compound(topAttrDef));
-                    const struct hdql_Compound * ct = hdql_attr_def_compound_type_info(topAttrDef);
-                    if(!hdql_compound_is_virtual(ct)) {
-                        printf( "compound %s instance %p of type `%s'"
-                              , hdql_attr_def_is_collection(topAttrDef) ? "collection" : "scalar"
-                              , r
-                              , hdql_compound_get_name(hdql_attr_def_compound_type_info(topAttrDef))
-                              );
-                    } else {
-                        char buf[128];
-                        hdql_compound_get_full_type_str(ct, buf, sizeof(buf));
-                        printf( "compound %s instance %p of type `%s'"
-                              , hdql_attr_def_is_collection(topAttrDef) ? "collection" : "scalar"
-                              , r
-                              , buf
-                              );
-                    }
-                } else {  // atomic item
-                    if(!hdql_attr_def_is_collection(topAttrDef)) {  // scalar compound attribute
-                        // xxx, example: `.eventID', `.hits.x'
-                        const hdql_ValueInterface * vi = hdql_types_get_type(valTypes
-                                , hdql_attr_def_get_atomic_value_type_code(topAttrDef) );
-                        if(!vi) {
-                            printf( "scalar instance %p of unknown type", r);
-                        } else if(!vi->get_as_string) {
-                            printf( "scalar instance %p of type <%s> (no to-string method)"
-                                    , r, vi->name );
-                        } else {
-                            char valueBf[32];
-                            vi->get_as_string(r, valueBf, sizeof(valueBf), ctx);
-                            printf( "scalar instance %p of type <%s> with value \"%s\""
-                                    , r, vi->name, valueBf );
-                        }
-                    } else {  // item from collection of atomic scalars (1d list or array)
-                        // xxx, example: `.hits.rawData.samples'
-                        #if 1
-                        const hdql_ValueInterface * vi
-                            = hdql_types_get_type(valTypes, hdql_attr_def_get_atomic_value_type_code(topAttrDef));
-                        if(vi && vi->get_as_string) {
-                            char bf[32];
-                            vi->get_as_string(r, bf, sizeof(bf), ctx);
-                            printf( "value=\"%s\"", bf );
-                        } else {
-                            fputs(" (no value interface)", stdout);
-                        }
-                        #else
-                        // Query resulted in weird item
-                        printf("??? (attr.def. provided, %s, %s, %s %s)"
-                              , topAttrDef->staticValueFlags ? "stat.val." : "not a static value"
-                              , topAttrDef->isSubQuery ? "subquery" : "not a subquery"
-                              , topAttrDef->isAtomic ? "atomic" : "compound"
-                              , topAttrDef->isCollection ? "collection" : "scalar"
-                              );
-                        #endif
-                    }
-                }
-                puts(".");
+                shallow_print_value(r, topAttrDef, ctx);
             }  // end of valid result handling
 
             #if 0

--- a/test/samples.cc
+++ b/test/samples.cc
@@ -67,6 +67,7 @@ fill_data_sample_2( Event & ev ) {
                        , h14 = std::make_shared<Hit>(Hit{14, 24, 3.1, 4.1, 5.9, rawData5})
                        ;
 
+    ev.hits.clear();
     ev.hits.emplace(401, h10);
     ev.hits.emplace(402, h11);
     ev.hits.emplace(450, h12);
@@ -78,7 +79,6 @@ fill_data_sample_2( Event & ev ) {
                          , t3 = std::make_shared<Track>(Track{12.0, 1, 0.001 })
                          ;
 
-    ev.hits.clear();
     // t1 uses two early hits + one later hit
     t1->hits.emplace(401, h10);
     t1->hits.emplace(402, h11);
@@ -115,6 +115,7 @@ fill_data_sample_3( Event & ev ) {
                        , h24 = std::make_shared<Hit>(Hit{10, 11,  5.5,  6.6,  7.7, rawData5})
                        ;
 
+    ev.hits.clear();
     ev.hits.emplace( 10, h20);
     ev.hits.emplace( 11, h21);
     ev.hits.emplace( 12, h22);
@@ -127,8 +128,8 @@ fill_data_sample_3( Event & ev ) {
                          , tD = std::make_shared<Track>(Track{ 1.0, 1, 0.20 })
                          ;
 
-    ev.hits.clear();
     // tA: three consecutive hits
+    tA->hits.clear();
     tA->hits.emplace(10, h20);
     tA->hits.emplace(11, h21);
     tA->hits.emplace(12, h22);


### PR DESCRIPTION
* Introduces binding operator (`{*<sub-query>}` syntax) resulting in a bound attributes and bound compound, effectively resolving Cartesian product/parent scope access problem.
* Introduces positional compound attributes (`#1`, `#2` syntax, etc).
* Fixin minor leaks.
Closes #11